### PR TITLE
Tidy monospaced blocks and inlines

### DIFF
--- a/content/en/docs/Installation/_index.md
+++ b/content/en/docs/Installation/_index.md
@@ -61,17 +61,17 @@ To check the Kyverno controller status, run the command:
 ```sh
 ## Check pod status
 kubectl get pods -n <namespace>
-````
+```
 
 If the Kyverno controller is not running, you can check its status and logs for errors:
 
-````sh
+```sh
 kubectl describe pod <kyverno-pod-name> -n <namespace>
-````
+```
 
-````sh
+```sh
 kubectl logs <kyverno-pod-name> -n <namespace>
-````
+```
 
 ### Option 2: Use your own CA-signed certificate
 
@@ -167,11 +167,11 @@ Kyverno, in `foreground` mode, leverages admission webhooks to manage incoming a
 
 ClusterRoles used by kyverno:
 
-- kyverno:webhook
-- kyverno:userinfo
-- kyverno:customresources
-- kyverno:policycontroller
-- kyverno:generatecontroller
+- `kyverno:webhook`
+- `kyverno:userinfo`
+- `kyverno:customresources`
+- `kyverno:policycontroller`
+- `kyverno:generatecontroller`
 
 The `generate` rule creates a new resource, and to allow Kyverno to create resources the Kyverno ClusterRole needs permissions to create/update/delete. This can be done by adding the resource to the ClusterRole `kyverno:generatecontroller` used by Kyverno or by creating a new ClusterRole and a ClusterRoleBinding to Kyverno's default ServiceAccount.
 
@@ -230,14 +230,14 @@ To install in a specific namespace replace the namespace "kyverno" with your nam
 
 Example:
 
-````sh
+```yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: <namespace>
-````
+```
 
-````sh
+```yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -245,31 +245,31 @@ metadata:
     app: kyverno
   name: kyverno-svc
   namespace: <namespace>
-````
+```
 
 and in other places (ServiceAccount, ClusterRoles, ClusterRoleBindings, ConfigMaps, Service, Deployment) where namespace is mentioned.
 
 To run kyverno:
 
-````sh
+```sh
 kubectl create -f ./install.yaml
-````
+```
 
 To check the Kyverno controller status, run the command:
 
-````sh
+```sh
 kubectl get pods -n <namespace>
-````
+```
 
 If the Kyverno controller is not running, you can check its status and logs for errors:
 
-````sh
+```sh
 kubectl describe pod <kyverno-pod-name> -n <namespace>
-````
+```
 
-````sh
+```sh
 kubectl logs <kyverno-pod-name> -n <namespace>
-````
+```
 
 Here is a script that generates a self-signed CA, a TLS certificate-key pair, and the corresponding kubernetes secrets: [helper script](/scripts/generate-self-signed-cert-and-k8secrets.sh)
 

--- a/content/en/docs/Kyverno CLI/_index.md
+++ b/content/en/docs/Kyverno CLI/_index.md
@@ -67,7 +67,7 @@ Passing policy from stdin:
 kustomize build nginx/overlays/envs/prod/ | kyverno validate -
 ```
 
-Use the -o <yaml/json> flag to display the mutated policy.
+Use the `-o <yaml/json>` flag to display the mutated policy.
 
 Example:
 
@@ -87,7 +87,7 @@ kyverno validate /path/to/policy1.yaml -c /path/to/crd.yaml -c /path/to/folderFu
 
 Applies policies on resources, and supports applying multiple policies on multiple resources in a single command. The command also supports applying the given policies to an entire cluster. The current kubectl context will be used to access the cluster.
 
-Displays mutate results to stdout, by default. Use the -o <path> flag to save mutated resources to a file or directory.
+Displays mutate results to stdout, by default. Use the `-o <path>` flag to save mutated resources to a file or directory.
 
 Apply to a resource:
 ```
@@ -116,19 +116,19 @@ kyverno apply /path/to/policy.yaml --resource /path/to/resource.yaml -o <file pa
 
 Apply policy with variables:
 
-Use --set flag to pass the values for variables in a policy while applying on a resource.
+Use the `--set` flag to pass the values for variables in a policy while applying on a resource.
 
 ```
 kyverno apply /path/to/policy.yaml --resource /path/to/resource.yaml --set <variable1>=<value1>,<variable2>=<value2>
 ```
 
-Use --values_file for applying multiple policies on multiple resources and pass a file containing variables and its values.
+Use `--values_file` for applying multiple policies on multiple resources and pass a file containing variables and its values.
 
 ```
 kyverno apply /path/to/policy1.yaml /path/to/policy2.yaml --resource /path/to/resource1.yaml --resource /path/to/resource2.yaml -f /path/to/value.yaml
 ```
 
-Format of value.yaml :
+Format of `value.yaml`:
 
 ```yaml
 policies:
@@ -156,7 +156,7 @@ policies:
 
 Example:
 
-Policy file(add_network_policy.yaml):
+Policy manifest (`add_network_policy.yaml`):
 
 ```yaml
 apiVersion: kyverno.io/v1
@@ -192,7 +192,7 @@ spec:
           - Ingress
 ```
 
-Resource file(required_default_network_policy.yaml) :
+Resource manifest (`required_default_network_policy.yaml`):
 
 ```yaml
 kind: Namespace
@@ -201,15 +201,15 @@ metadata:
     name: "devtest"
 ```
 
-Applying policy on resource using set/-s flag:
+Applying policy on resource using `--set` or `-s` flag:
 
 ```
 kyverno apply /path/to/add_network_policy.yaml --resource /path/to/required_default_network_policy.yaml -s request.object.metadata.name=devtest
 ```
 
-Applying policy on resource using --values_file/-f flag:
+Applying policy on resource using `--values_file` or `-f` flag:
 
-YAML file with variables(value.yaml) :
+YAML file containing variables (`value.yaml`):
 
 ```yaml
 policies:

--- a/content/en/docs/Policy Violations/_index.md
+++ b/content/en/docs/Policy Violations/_index.md
@@ -14,8 +14,10 @@ Policy Violation objects are created in the resource namespace. Policy Violation
 
 You can view all existing policy violations as shown below:
 
-````bash
-$ kubectl get polv --all-namespaces
+```bash
+kubectl get polv --all-namespaces
+```
+```
 NAMESPACE   NAME                        POLICY                RESOURCEKIND   RESOURCENAME                  AGE
 default     disallow-root-user-56j4t    disallow-root-user    Deployment     nginx-deployment              5m7s
 default     validation-example2-7snmh   validation-example2   Deployment     nginx-deployment              5m7s
@@ -25,7 +27,7 @@ docker      disallow-root-user-s5rjp    disallow-root-user    Deployment     com
 docker      disallow-root-user-w58kp    disallow-root-user    Deployment     compose-api                   43m
 docker      validation-example2-dgj9j   validation-example2   Deployment     compose                       5m28s
 docker      validation-example2-gzfdf   validation-example2   Deployment     compose-api                   5m27s
-````
+```
 
 # Cluster Policy Violations
 

--- a/content/en/docs/Writing policies/match-exclude.md
+++ b/content/en/docs/Writing policies/match-exclude.md
@@ -21,7 +21,7 @@ When Kyverno receives an admission controller request, i.e. a validation or muta
 
 The following YAML provides an example for a match clause.
 
-````yaml
+```yaml
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -65,13 +65,13 @@ spec:
 
         ...
 
-````
+```
 
 ## Exclude `cluster-admin` role
 
 Here is an example of a rule that matches all pods, excluding pods created by using the `cluster-admin` cluster role.
 
-````yaml
+```yaml
 spec:
   rules:
     name: "match-pods-except-admin"
@@ -81,13 +81,13 @@ spec:
         - Pod
     exclude:
       clusterroles: cluster-admin
-````
+```
 
 ## Exclude `kube-system` namespace
 
 This rule matches all pods, excluding pods in the `kube-system` namespace.
 
-````yaml
+```yaml
 spec:
   rules:
     name: "match-pods-except-admin"
@@ -99,7 +99,7 @@ spec:
       resources:
         namespaces:
         - "kube-system"
-````
+```
 
 ## Combining match and exclude
 
@@ -111,7 +111,7 @@ Condition checks inside the `resources` block follow the logic "**AND across typ
 
 This is an example that selects a Deployment **OR** a StatefulSet with a label `app=critical`.
 
-````yaml
+```yaml
 spec:
   rules:
     - name: match-critical-app
@@ -124,13 +124,13 @@ spec:
           selector:
             matchLabels:
               app: critical
-````
+```
 
 ## Match a label and exclude users and roles
 
-The following example matches all resources with label `app=critical` excluding the resource created by ClusterRole `cluster-admin` **OR** by the user `John`.
+The following example matches all resources with label `app=critical` excluding the resources created by ClusterRole `cluster-admin` **OR** by the user `John`.
 
-````yaml
+```yaml
 spec:
   rules:
     - name: match-criticals-except-given-rbac
@@ -145,13 +145,13 @@ spec:
         subjects:
         - kind: User
           name: John
-````
+```
 
 ## Match all pods and exclude using annotations
 
 Here is an example of a rule that matches all pods having 'imageregistry: "https://hub.docker.com/"' annotations.
 
-````yaml
+```yaml
 spec:
   rules:
     - name: match-pod-annotations
@@ -162,4 +162,4 @@ spec:
           kinds:
             - Pod
           name: "*"
-````
+```

--- a/content/en/docs/Writing policies/mutate.md
+++ b/content/en/docs/Writing policies/mutate.md
@@ -49,7 +49,7 @@ With Kyverno, the add and replace have the same behavior i.e. both operations wi
 
 This patch policy adds, or replaces, entries in a `ConfigMap` with the name `config-game` in any namespace.
 
-````yaml
+```yaml
 apiVersion : kyverno.io/v1
 kind : ClusterPolicy
 metadata :
@@ -72,11 +72,11 @@ spec :
           - path : "/data/newKey1"
             op : add
             value : newValue1
-````
+```
 
 If your ConfigMap has empty data, the following policy adds an entry to `config-game`.
 
-````yaml
+```yaml
 apiVersion : kyverno.io/v1
 kind : ClusterPolicy
 metadata :
@@ -94,11 +94,11 @@ spec :
           - path: "/data"
             op: add
             value: {"ship.properties": "{\"type\": \"starship\", \"owner\": \"utany.corp\"}"}
-````
+```
 
 Here is the example of a patch that removes a label from the secret:
 
-````yaml
+```yaml
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -114,11 +114,11 @@ spec:
         patchesJson6902: |-
           - path: "/metadata/labels/purpose"
             op: remove
-````
+```
 
 This policy rule adds elements to list:
 
-````yaml
+```yaml
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -139,7 +139,7 @@ spec:
             path: /spec/containers/0/command
             value:
             - ls
-````
+```
 
 Note, that if **remove** operation cannot be applied, then this **remove** operation will be skipped with no error.
 
@@ -149,7 +149,7 @@ The `kubectl` command uses a [strategic merge patch](https://github.com/kubernet
 
 This policy sets the imagePullPolicy, adds command to container `nginx`:
 
-````yaml
+```yaml
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -173,7 +173,7 @@ spec:
                 imagePullPolicy: "Never"
                 command:
                 - ls
-````
+```
 
 ## Mutate Overlay
 
@@ -183,7 +183,7 @@ The overlay cannot be used to delete values in a resource: use **patches** for t
 
 The following mutation overlay will add (or replace) the memory request and limit to 10Gi for every Pod with a label `memory: high`:
 
-````yaml
+```yaml
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -210,13 +210,13 @@ spec:
                 limits:
                   memory: "10Gi"
 
-````
+```
 
 ### Working with lists
 
 Applying overlays to a list type is fairly straightforward: new items will be added to the list, unless they already exist. For example, the next overlay will add IP "192.168.10.172" to all addresses in all Endpoints:
 
-````yaml
+```yaml
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -233,7 +233,7 @@ spec:
         subsets:
         - addresses:
           - ip: 192.168.42.172
-````
+```
 
 ### Conditional logic using anchors
 
@@ -257,7 +257,7 @@ A `conditional anchor` evaluates to `true` if the anchor tag exists and if the v
 
  For example, this overlay will add or replace the value `6443` for the `port` field, for all ports with a name value that starts with "secure":
 
-````yaml
+```yaml
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -275,7 +275,7 @@ spec:
         - ports:
           - (name): "secure*"
             port: 6443
-````
+```
 
 If the anchor tag value is an object or array, the entire object or array must match. In other words, the entire object or array becomes part of the "if" clause. Nested `conditional anchor` tags are not supported.
 
@@ -287,7 +287,7 @@ An `add anchor` is processed as part of applying the mutation. Typically, every 
 
 For example, this policy matches and mutates pods with `emptyDir` volume, to add the `safe-to-evict` annotation if it is not specified.
 
-````yaml
+```yaml
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -309,7 +309,7 @@ spec:
         spec:
           volumes:
           - (emptyDir): {}
-````
+```
 
 #### Anchor processing flow
 

--- a/content/en/docs/Writing policies/variables.md
+++ b/content/en/docs/Writing policies/variables.md
@@ -87,13 +87,15 @@ This sample will mutate all incoming `Pod` creation requests with a label named 
 Create a simple `Pod` resource.
 
 ```sh
-$ kubectl run busybox --image busybox:1.28
+kubectl run busybox --image busybox:1.28
 ```
 
 Now `get` the newly-created `busybox` Pod.
 
 ```sh
-$ kubectl get po busybox --show-labels
+kubectl get po busybox --show-labels
+```
+```
 NAME       READY   STATUS    RESTARTS   AGE   LABELS
 busybox   0/1     Pending   0          25m   created-by=kubernetes-admin,run=busybox
 ```
@@ -202,7 +204,9 @@ data:
 Once created, `describe` the resource to see how the array of strings is stored.
 
 ```sh
-$ kubectl describe cm roles-dictionary
+kubectl describe cm roles-dictionary
+```
+```
 Name:         roles-dictionary
 Namespace:    default
 Labels:       <none>
@@ -283,7 +287,9 @@ spec:
 Submit the manifest and see how Kyverno reacts.
 
 ```sh
-$ kubectl create -f deploy.yaml
+kubectl create -f deploy.yaml
+```
+```
 Error from server: error when creating "deploy.yaml": admission webhook "nirmata.kyverno.resource.validating-webhook" denied the request:
 
 resource Deployment/default/busybox was blocked due to the following policies


### PR DESCRIPTION
Taking a steer from the Kubernetes documentation [style guide](https://kubernetes.io/docs/contribute/style/style-guide/), fix Markdown for code blocks and monospaced inlines.

- mark YAML as YAML
- don't include the prompt in code highlighted as shell
- use CommonMark preformatted blocks (<tt>\`\`\`</tt> delimited)

Plus a few wording tweaks that I could separate out but will only create merge conflicts if I do.