### PR TITLE
Fix image name for local previewing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ NETLIFY_FUNC      = $(NODE_BIN)/netlify-lambda
 # CONTAINER_ENGINE=podman make container-image
 CONTAINER_ENGINE ?= docker
 IMAGE_VERSION=$(shell scripts/hash-files.sh Dockerfile Makefile | cut -c 1-12)
-CONTAINER_IMAGE   = kubernetes-hugo:v$(HUGO_VERSION)-$(IMAGE_VERSION)
+CONTAINER_IMAGE   = kyverno-hugo:v$(HUGO_VERSION)-$(IMAGE_VERSION)
 CONTAINER_RUN     = $(CONTAINER_ENGINE) run --rm --interactive --tty --volume $(CURDIR):/src
 
 CCRED=\033[0;31m

--- a/scripts/hash-files.sh
+++ b/scripts/hash-files.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# this script emits as hash for the files listed in $@
+if command -v shasum >/dev/null 2>&1; then
+  cat "$@" | shasum -a 256 | cut -d' ' -f1
+elif command -v sha256sum >/dev/null 2>&1; then
+  cat "$@" | sha256sum | cut -d' ' -f1
+else
+  echo "missing shasum tool" 1>&2
+  exit 1
+fi


### PR DESCRIPTION
The name _kubernetes-hugo_ came from the Kubernetes [_k/website_](https://github.com/kubernetes/website/pulls) repo where this `Makefile` originated. Switch to _kyverno-hugo_.

Also, bring over a missing `scripts/hash-files.sh` from that repo.