### PR TITLE
Use YouTube shortcode for videos

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -58,3 +58,10 @@ footer {
 }
 
 @import "styles_project";
+
+.videos {
+  display: flex;
+}
+.videos > .video {
+  margin-right: 1.5rem;
+}

--- a/content/en/resources/_index.md
+++ b/content/en/resources/_index.md
@@ -8,17 +8,16 @@ type: docs
 
 *Click to play videos*
 
-<a href="https://www.youtube.com/watch?v=DW2u6LhNMh0&feature=youtu.be&t=116">
-<img src="https://img.youtube.com/vi/DW2u6LhNMh0/0.jpg" width="250">
-</a>
+{{% videos %}}
 
-<a href="https://www.youtube.com/watch?v=ZE4Zu9WQET4&feature=youtu.be&t=1621">
-<img src="https://img.youtube.com/vi/ZE4Zu9WQET4/0.jpg" width="250">
-</a>
+{{< youtube id="DW2u6LhNMh0" start="116" class="video" >}}
 
-<a href="https://www.youtube.com/watch?v=Mukbfbr2b_k&t=1053">
-<img src="https://img.youtube.com/vi/Mukbfbr2b_k/0.jpg" width="250">
-</a>
+{{< youtube id="ZE4Zu9WQET4" start="1621" class="video" >}}
+
+{{< youtube id="Mukbfbr2b_k" start="1053" class="video" >}}
+
+
+{{% /videos %}}
 
 ## Blogs
 

--- a/layouts/shortcodes/videos.html
+++ b/layouts/shortcodes/videos.html
@@ -1,0 +1,3 @@
+<div class="videos">
+  {{ .Inner }}
+</div>

--- a/layouts/shortcodes/youtube.html
+++ b/layouts/shortcodes/youtube.html
@@ -1,0 +1,19 @@
+{{- $pc := .Page.Site.Config.Privacy.YouTube -}}
+{{- if not $pc.Disable -}}
+{{- $ytHost := cond $pc.PrivacyEnhanced  "www.youtube-nocookie.com" "www.youtube.com" -}}
+{{- $id := .Get "id" | default (.Get 0) -}}
+{{- $class := .Get "class" | default (.Get 1) -}}
+{{- $params := slice -}}
+{{- if eq (.Get "autoplay") "true" -}}
+    {{- $params = $params | append (querify "autoplay" 1) -}}
+{{- end -}}
+{{- with (.Get "start") -}}
+    {{- $params = $params | append (querify "start" (. | int)) -}}
+{{- end -}}
+{{- with (.Get "end") -}}
+    {{- $params = $params | append (querify "end" (. | int)) -}}
+{{- end }}
+<div {{ with $class }}class="{{ . }}"{{ else }}style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"{{ end }}>
+  <iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with $params }}?{{ delimit $params "&" | safeURL }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="YouTube Video"></iframe>
+</div>
+{{ end -}}


### PR DESCRIPTION
Switch from using inline HTML to a Hugo [shortcode](https://gohugo.io/content-management/shortcodes/) that references the same YouTube videos.