### PR TITLE
docs(preconditions): fixed definition of NotIn for sets

### DIFF
--- a/content/en/docs/Writing policies/preconditions.md
+++ b/content/en/docs/Writing policies/preconditions.md
@@ -31,7 +31,7 @@ The following operators are currently supported for precondition evaluation:
 - In
 - NotIn
 
-The set operators, `In` and `NotIn` support a set of strings as the value (e.g. In ["str1", "str2"]). They also allow you to specify a set of strings as the key (e.g. ["str1", "str2"] In ["str1", "str2", "str3"]). In this case `In` checks if **all** the strings part of the key are in the value set and `NotIn` checks if **none** of the strings part of the key are in the value set. Sets of other types are currently not supported.
+The set operators, `In` and `NotIn` support a set of strings as the value (e.g. In ["str1", "str2"]). They also allow you to specify a set of strings as the key (e.g. ["str1", "str2"] In ["str1", "str2", "str3"]). In this case `In` checks if **all** the strings part of the key are in the value set (i.e. key is a subset of value) and `NotIn` checks if **any** of the strings part of the key is **not** in the value set (i.e. key is not a subset of value). Sets of other types are currently not supported.
 
 ## Matching requests without a service account
 


### PR DESCRIPTION
Signed-off-by: Arsh Sharma <arshsharma461@gmail.com>

Reasoning:
If **any** of the strings part of the key is **not** in the value set then it is reason enough for NotIn to say that it is not a subset and return true.