### PR TITLE
Update example in `Negation` behavior

### DIFF
--- a/content/en/docs/Writing policies/validate.md
+++ b/content/en/docs/Writing policies/validate.md
@@ -188,7 +188,7 @@ Anchors allow conditional processing (i.e. "if-then-else") and other logical che
 | Conditional | ()  | If tag with the given value (including child elements) is specified, then peer elements will be processed. <br/>e.g. If image has tag latest then imagePullPolicy cannot be IfNotPresent. <br/>&nbsp;&nbsp;&nbsp;&nbsp;(image): "*:latest" <br>&nbsp;&nbsp;&nbsp;&nbsp;imagePullPolicy: "!IfNotPresent"<br/>                                             |
 | Equality    | =() | If tag is specified, then processing continues. For tags with scalar values, the value must match. For tags with child elements, the child element is further evaluated as a validation pattern.  <br/>e.g. If hostPath is defined then the path cannot be /var/lib<br/>&nbsp;&nbsp;&nbsp;&nbsp;=(hostPath):<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path: "!/var/lib"<br/>                                                                                  |
 | Existence   | ^() | Works on the list/array type only. If at least one element in the list satisfies the pattern. In contrast, a conditional anchor would validate that all elements in the list match the pattern. <br/>e.g. At least one container with image nginx:latest must exist. <br/>&nbsp;&nbsp;&nbsp;&nbsp;^(containers):<br/>&nbsp;&nbsp;&nbsp;&nbsp;- image: nginx:latest<br/>  |
-| Negation    | X() | The tag cannot be specified. The value of the tag is not evaluated. <br/>e.g. Hostpath tag cannot be defined.<br/>&nbsp;&nbsp;&nbsp;&nbsp;X(hostPath):<br/>|
+| Negation    | X() | The tag cannot be specified. The value of the tag is not evaluated. <br/>e.g. Hostpath tag cannot be defined.<br/>&nbsp;&nbsp;&nbsp;&nbsp;X(hostPath): null<br/>|
 
 #### Anchors and child elements: Conditional and Equality
 


### PR DESCRIPTION
The `Negation` behavior [says][1] the value will not be evaluated. However, if we leave the value blank, that rule doesn't work at all.

```yaml
# ...(omitted)
    X(hostPath): # nothing here in original document
```

Maybe put a `null` as the value here like [host network sample][2] to make it more clear?

[1]: https://kyverno.io/docs/writing-policies/validate/#anchors
[2]: https://github.com/kyverno/kyverno/blob/main/samples/best_practices/disallow_host_network_port.yaml#L34