### PR TITLE
fix shell execution in example

### DIFF
--- a/content/en/docs/Introduction/_index.md
+++ b/content/en/docs/Introduction/_index.md
@@ -78,7 +78,7 @@ spec:
         kinds:
         - Pod
     validate:
-      message: "label `app.kubernetes.io/name` is required"
+      message: "label 'app.kubernetes.io/name' is required"
       pattern:
         metadata:
           labels:


### PR DESCRIPTION
When we create the policy in the quick start example, the character ` makes the shell execute and an error is reported. As a consequence, the validation message shows incorrectly.

```
kubectl create -f- << EOF
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels
spec:
  validationFailureAction: enforce
  rules:
  - name: check-for-labels
    match:
      resources:
        kinds:
        - Pod
    validate:
      message: "label `app.kubernetes.io/name` is required"
      pattern:
        metadata:
          labels:
            app.kubernetes.io/name: "?*"
EOF
zsh: no such file or directory: app.kubernetes.io/name
clusterpolicy.kyverno.io/require-labels created
```

```
kubectl create deployment nginx --image=nginx
Error from server: admission webhook "validate.kyverno.svc" denied the request:

resource Deployment/default/nginx was blocked due to the following policies

require-labels:
  autogen-check-for-labels: 'validation error: label  is required. Rule autogen-check-for-labels failed at path /spec/template/metadata/labels/app.kubernetes.io/name/'
```