### PR TITLE
Add any/all documentation

### DIFF
--- a/content/en/docs/Writing policies/preconditions.md
+++ b/content/en/docs/Writing policies/preconditions.md
@@ -59,7 +59,7 @@ spec:
         command: ["sleep", "9999"]
 ```
 
-Using `any` and `all` blocks in the `preconditions` statement, it is possible to gain more granular control over when rules are evaluated. In the below sample policy, using an `any` block will allow the `preconditions` to work as a logical OR operation. This policy will only perform the validation if labels `color=blue` OR `app=busybox` are found. Because the Deployment manifest above specified `color=red`, using the `any` statement still allows the validation to occur.
+By using `any` and `all` blocks in the `preconditions` statement, it is possible to gain more granular control over when rules are evaluated. In the below sample policy, using an `any` block will allow the `preconditions` to work as a logical OR operation. This policy will only perform the validation if labels `color=blue` OR `app=busybox` are found. Because the Deployment manifest above specified `color=red`, using the `any` statement still allows the validation to occur.
 
 ```yaml
 apiVersion: kyverno.io/v1

--- a/content/en/docs/Writing policies/preconditions.md
+++ b/content/en/docs/Writing policies/preconditions.md
@@ -23,7 +23,7 @@ You may specify multiple statements in the `preconditions` field. The use of mul
 
 ## Any and All Statements
 
-You may further control how `preconditions` are evaluated by nesting the expressions under `any` and/or `all` statements. This gives you further power in building more precise logic for how the rule is triggered. Either or both may be used simultaneously in the same rule with multiple `any` statements also being possible. For each `any`/`all` statement, each block must overall evaluate to TRUE for the precondition to be processed. If any of the `any` / `all` statement blocks does not evaluate to TRUE, `preconditions` will not be satisfied and thus the rule will not be applicable.
+You may further control how `preconditions` are evaluated by nesting the expressions under `any` and/or `all` statements. This gives you further power in building more precise logic for how the rule is triggered. Either or both may be used simultaneously in the same rule with multiple `any` statements also being possible (multiple `all` statements would be redundant). For each `any`/`all` statement, each block must overall evaluate to TRUE for the precondition to be processed. If any of the `any` / `all` statement blocks does not evaluate to TRUE, `preconditions` will not be satisfied and thus the rule will not be applicable.
 
 {{% alert title="Note" color="info" %}}
 `any` and `all` statements are available starting in Kyverno v1.3.4 but are optional. Users can continue to write multiple statements inside the `preconditions` field and have them evaluated as a logical AND statement.

--- a/content/en/docs/Writing policies/validate.md
+++ b/content/en/docs/Writing policies/validate.md
@@ -350,7 +350,7 @@ You can use `match` and `exclude` to select when the rule should be applied and 
 When using a `deny` statement, `validationFailureAction` must be set to `enforce` to block the request.
 {{% /alert %}}
 
-Also see using [Preconditions](/docs/writing-policies/preconditions) for matching rules based on variables.
+Also see using [Preconditions](/docs/writing-policies/preconditions) for matching rules based on variables. `deny` statements can similarly use `any` and `all` blocks like those available to `preconditions`.
 
 In addition to admission review request data, user information, and built-in variables, `deny` rules and preconditions can also operate on ConfigMap data, and in the future data from API server lookups, etc.
 


### PR DESCRIPTION
Adds documentation for the `any`/`all` statement blocks referenced in https://github.com/kyverno/kyverno/issues/1765 (see referenced PR and parent issue) which adds functionality to `validate.deny.conditions` and `preconditions` objects. The ultimate objective would be to link to the same section under the preconditions portion of these docs when this capability is expanded to other Kyverno sections as outlined in https://github.com/kyverno/kyverno/issues/1485 (such as `pattern`, `anyPattern`, `matchExpressions`, and `matchLabels`)

Closes #104 