### PR TITLE
include policy bugfix #47 into website: allow fsGroup values greater than zero

### DIFF
--- a/content/en/policies/pod-security/restricted/require-non-root-groups/require-non-root-groups.md
+++ b/content/en/policies/pod-security/restricted/require-non-root-groups/require-non-root-groups.md
@@ -64,11 +64,11 @@ spec:
             - Pod
       validate:
         message: >-
-          Changing of file system groups is not allowed. The field	
-          spec.securityContext.fsGroup must not be defined.
+          Changing to root group ID is disallowed. The field
+          spec.securityContext.fsGroup must be empty or greater than zero.
         pattern:
           spec:
             =(securityContext):
-              X(fsGroup): "*"
+              =(fsGroup): ">0"
 
 ```


### PR DESCRIPTION
change the policy require-non-root-groups to allow fsGroup values greater than zero