### PR TITLE
Add subject to policy filters

### DIFF
--- a/assets/js/policy.js
+++ b/assets/js/policy.js
@@ -17,23 +17,34 @@ const appliedFiltersEl = elem(".filters_applied");
 const section = elem(".td-section");
 
 // add filters on the sidebar
+function createFilterButton(filter, parent) {
+  let filterButton = createEl();
+  filterButton.className = "filter";
+  filterButton.textContent = filter.trim();
+  parent.appendChild(filterButton);
+}
+
 function populateFilters(data) {
   elem("#policy_filters").dataset.filters.split(",").forEach(function(filterType){
     let filters = new Set();
     data.forEach(function(item){
-      filters.add(item[filterType]);
+      item[filterType] ? filters.add(item[filterType]) : false;
     });
     let filterTypeEl = elem(`.filter_${filterType}`);
     const filterCategory = { "type": filterTypeEl.dataset.criteria, "policies": Array.from(filters) };
     allFiltersObj.push(filterCategory);
-    
+
     if(data.length >= 1) {
       if (filters.size >= 1) {
         Array.from(filters).sort().forEach(function(filter){
-          let filterButton = createEl();
-          filterButton.className = "filter";
-          filterButton.textContent = filter;
-          filterTypeEl.appendChild(filterButton);
+          let actualFilters = filter.split(",");
+          if(actualFilters.length > 1) {
+            actualFilters.forEach(filter => {
+              createFilterButton(filter, filterTypeEl);
+            })
+          } else {
+            createFilterButton(filter, filterTypeEl);
+          }
         });
       } else {
         filterTypeEl.classList.add("passive");
@@ -46,6 +57,7 @@ function createPolicy(body, link, policy, title) {
   const policyElem = document.createElement("a");
   policyElem.className = "policy";
   policyElem.href = link;
+  policy = policy.replaceAll(", ", "::").replaceAll(" ,", "::").replaceAll(",", "::");
   policyElem.dataset.policy = policy;
   const policyTitle = document.createElement("h3");
   policyTitle.className = "policy_title";

--- a/assets/js/policy.js
+++ b/assets/js/policy.js
@@ -18,10 +18,17 @@ const section = elem(".td-section");
 
 // add filters on the sidebar
 function createFilterButton(filter, parent) {
-  let filterButton = createEl();
-  filterButton.className = "filter";
-  filterButton.textContent = filter.trim();
-  parent.appendChild(filterButton);
+  const id = "filter";
+  const label = filter.trim();
+  const buttonAlreadyExists = Array.from(elems(`.${id}`, parent)).filter(button => {
+    return button.textContent.toLowerCase() === label.toLowerCase();
+  });
+  if(buttonAlreadyExists.length < 1) {
+    let filterButton = createEl();
+    filterButton.className = id;
+    filterButton.textContent = label;
+    parent.appendChild(filterButton);
+  }
 }
 
 function populateFilters(data) {

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -68,6 +68,11 @@ title = "Minimum Version" # title on the UI
 filterID = "version" # key you used inside index.json 
 weight = 3
 
+[[policyFilters]]
+title = "Subject" # title on the UI
+filterID = "subject" # key you used inside index.json 
+weight = 4
+
 # User interface configuration
 [ui]
 

--- a/content/en/policies/best-practices/add_network_policy.md
+++ b/content/en/policies/best-practices/add_network_policy.md
@@ -2,6 +2,7 @@
 title: "Add Network Policy"
 category: Multi-Tenancy
 version: 
+subject: NetworkPolicy
 policyType: "generate"
 description: >
     By default, Kubernetes allows communications across all pods within a cluster.  Network policies and, a CNI that supports network policies, must be used to restrict  communications. A default NetworkPolicy should be configured for each namespace to  default deny all ingress and egress traffic to the pods in the namespace. Application  teams can then configure additional NetworkPolicy resources to allow desired traffic  to application pods from select sources.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Add Network Policy
     policies.kyverno.io/category: Multi-Tenancy
+    policies.kyverno.io/subject: NetworkPolicy
     policies.kyverno.io/description: >-
       By default, Kubernetes allows communications across all pods within a cluster. 
       Network policies and, a CNI that supports network policies, must be used to restrict 

--- a/content/en/policies/best-practices/add_ns_quota.md
+++ b/content/en/policies/best-practices/add_ns_quota.md
@@ -2,6 +2,7 @@
 title: "Add Quota"
 category: Multi-Tenancy
 version: 
+subject: ResourceQuota, LimitRange
 policyType: "generate"
 description: >
     To limit the number of objects, as well as the total amount of compute that  may be consumed by a single namespace, create a default resource quota for  each namespace.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Add Quota
     policies.kyverno.io/category: Multi-Tenancy
+    policies.kyverno.io/subject: ResourceQuota, LimitRange
     policies.kyverno.io/description: >-
       To limit the number of objects, as well as the total amount of compute that 
       may be consumed by a single namespace, create a default resource quota for 

--- a/content/en/policies/best-practices/add_safe_to_evict.md
+++ b/content/en/policies/best-practices/add_safe_to_evict.md
@@ -2,6 +2,7 @@
 title: "Add safe-to-evict"
 category: Best Practices
 version: 
+subject: Pod
 policyType: "mutate"
 description: >
     The Kubernetes cluster autoscaler does not evict pods that use hostPath  or emptyDir volumes. To allow eviction of these pods, the annotation  cluster-autoscaler.kubernetes.io/safe-to-evict=true must be added to pods. 
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Add safe-to-evict 
     policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       The Kubernetes cluster autoscaler does not evict pods that use hostPath 
       or emptyDir volumes. To allow eviction of these pods, the annotation 

--- a/content/en/policies/best-practices/disallow_cri_sock_mount/disallow_cri_sock_mount.md
+++ b/content/en/policies/best-practices/disallow_cri_sock_mount/disallow_cri_sock_mount.md
@@ -2,6 +2,7 @@
 title: "Disallow CRI socket mounts"
 category: Best Practices
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Container daemon socket bind mounts allows access to the container engine on the  node. This access can be used for privilege escalation and to manage containers  outside of Kubernetes, and hence should not be allowed.  
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Disallow CRI socket mounts
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Container daemon socket bind mounts allows access to the container engine on the 
       node. This access can be used for privilege escalation and to manage containers 

--- a/content/en/policies/best-practices/disallow_default_namespace/disallow_default_namespace.md
+++ b/content/en/policies/best-practices/disallow_default_namespace/disallow_default_namespace.md
@@ -2,6 +2,7 @@
 title: "Disallow Default Namespace"
 category: Multi-Tenancy
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Kubernetes namespaces are an optional feature that provide a way to segment and  isolate cluster resources across multiple applications and users. As a best  practice, workloads should be isolated with namespaces. Namespaces should be required  and the default (empty) namespace should not be used.
@@ -20,6 +21,7 @@ metadata:
     policies.kyverno.io/title: Disallow Default Namespace
     policies.kyverno.io/category: Multi-Tenancy
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Kubernetes namespaces are an optional feature that provide a way to segment and 
       isolate cluster resources across multiple applications and users. As a best 

--- a/content/en/policies/best-practices/disallow_helm_tiller/disallow_helm_tiller.md
+++ b/content/en/policies/best-practices/disallow_helm_tiller/disallow_helm_tiller.md
@@ -2,6 +2,7 @@
 title: "Disallow Helm Tiller"
 category: Sample
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Tiller has known security challenges. It requires administrative privileges and acts as a shared resource accessible to any authenticated user. Tiller can lead to privilege escalation as restricted users can impact other users.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Disallow Helm Tiller
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Tiller has known security challenges. It requires administrative privileges and acts as a shared
       resource accessible to any authenticated user. Tiller can lead to privilege escalation as

--- a/content/en/policies/best-practices/disallow_latest_tag/disallow_latest_tag.md
+++ b/content/en/policies/best-practices/disallow_latest_tag/disallow_latest_tag.md
@@ -2,6 +2,7 @@
 title: "Disallow Latest Tag"
 category: Best Practices
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     The ':latest' tag is mutable and can lead to unexpected errors if the  image changes. A best practice is to use an immutable tag that maps to  a specific version of an application pod.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Disallow Latest Tag
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       The ':latest' tag is mutable and can lead to unexpected errors if the 
       image changes. A best practice is to use an immutable tag that maps to 

--- a/content/en/policies/best-practices/require_drop_all/require_drop_all.md
+++ b/content/en/policies/best-practices/require_drop_all/require_drop_all.md
@@ -2,6 +2,7 @@
 title: "Drop All Capabilities"
 category: Best Practices
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Capabilities permit privileged actions without giving full root access. All  capabilities should be dropped from a pod, with only those required added back.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Drop All Capabilities
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Capabilities permit privileged actions without giving full root access. All 
       capabilities should be dropped from a pod, with only those required added back.

--- a/content/en/policies/best-practices/require_labels/require_labels.md
+++ b/content/en/policies/best-practices/require_labels/require_labels.md
@@ -2,6 +2,7 @@
 title: "Require Labels"
 category: Best Practices
 version: 
+subject: Pod, Label
 policyType: "validate"
 description: >
     Define and use labels that identify semantic attributes of your application or Deployment. A common set of labels allows tools to work collaboratively, describing objects in a common manner that  all tools can understand. The recommended labels describe applications in a way that can be  queried. 
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Require Labels
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod, Label
     policies.kyverno.io/description: >-
       Define and use labels that identify semantic attributes of your application or Deployment.
       A common set of labels allows tools to work collaboratively, describing objects in a common manner that 

--- a/content/en/policies/best-practices/require_pod_requests_limits/require_pod_requests_limits.md
+++ b/content/en/policies/best-practices/require_pod_requests_limits/require_pod_requests_limits.md
@@ -2,6 +2,7 @@
 title: "Require Limits and Requests"
 category: Multi-Tenancy
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     As application workloads share cluster resources, it is important to limit resources  requested and consumed by each pod. It is recommended to require 'resources.requests'  and 'resources.limits.memory' per pod. If a namespace level request or limit is specified,  defaults will automatically be applied to each pod based on the 'LimitRange' configuration.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Require Limits and Requests 
     policies.kyverno.io/category: Multi-Tenancy
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       As application workloads share cluster resources, it is important to limit resources 
       requested and consumed by each pod. It is recommended to require 'resources.requests' 

--- a/content/en/policies/best-practices/require_probes/require_probes.md
+++ b/content/en/policies/best-practices/require_probes/require_probes.md
@@ -2,6 +2,7 @@
 title: "Require Pod Probes"
 category: Best Practices
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Liveness and readiness probes need to be configured to correctly manage a pods  lifecycle during deployments, restarts, and upgrades. For each pod, a periodic  `livenessProbe` is performed by the kubelet to determine if the pod's containers  are running or need to be restarted. A `readinessProbe` is used by services  and deployments to determine if the pod is ready to receive network traffic.
@@ -20,6 +21,7 @@ metadata:
     policies.kyverno.io/title: Require Pod Probes
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Liveness and readiness probes need to be configured to correctly manage a pods 
       lifecycle during deployments, restarts, and upgrades. For each pod, a periodic 

--- a/content/en/policies/best-practices/require_ro_rootfs/require_ro_rootfs.md
+++ b/content/en/policies/best-practices/require_ro_rootfs/require_ro_rootfs.md
@@ -2,6 +2,7 @@
 title: "Require Read-Only Root Filesystem"
 category: Best Practices
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     A read-only root file system helps to enforce an immutable infrastructure strategy;  the container only needs to write on the mounted volume that persists the state.  An immutable root filesystem can also prevent malicious binaries from writing to the  host system.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Require Read-Only Root Filesystem
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       A read-only root file system helps to enforce an immutable infrastructure strategy; 
       the container only needs to write on the mounted volume that persists the state. 

--- a/content/en/policies/best-practices/restrict-service-external-ips/restrict-service-external-ips.md
+++ b/content/en/policies/best-practices/restrict-service-external-ips/restrict-service-external-ips.md
@@ -2,6 +2,7 @@
 title: "Restrict External IPs"
 category: Best Practices
 version: 
+subject: Service
 policyType: "validate"
 description: >
     Service externalIPs can be used for a MITM attack (CVE-2020-8554). Restrict externalIPs or limit to a known set of addresses. See: https://github.com/kyverno/kyverno/issues/1367.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Restrict External IPs
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Service
     policies.kyverno.io/description: >-
       Service externalIPs can be used for a MITM attack (CVE-2020-8554).
       Restrict externalIPs or limit to a known set of addresses.

--- a/content/en/policies/best-practices/restrict_image_registries/restrict_image_registries.md
+++ b/content/en/policies/best-practices/restrict_image_registries/restrict_image_registries.md
@@ -2,6 +2,7 @@
 title: "Restrict Image Registries"
 category: Best Practices
 version: 1.3.0
+subject: Pod
 policyType: "validate"
 description: >
     Images from unknown registries may not be scanned and secured.  Requiring use of known registries helps reduce threat exposure.
@@ -20,6 +21,7 @@ metadata:
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
     policies.kyverno.io/minversion: 1.3.0
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Images from unknown registries may not be scanned and secured. 
       Requiring use of known registries helps reduce threat exposure.

--- a/content/en/policies/best-practices/restrict_node_port/restrict_node_port.md
+++ b/content/en/policies/best-practices/restrict_node_port/restrict_node_port.md
@@ -2,6 +2,7 @@
 title: "Disallow NodePort"
 category: Best Practices
 version: 
+subject: Service
 policyType: "validate"
 description: >
     A Kubernetes service of type NodePort uses a host port to receive traffic from  any source. A 'NetworkPolicy' resource cannot be used to control traffic to host ports.  Although 'NodePort' services can be useful, their use must be limited to services  with additional upstream security checks.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Disallow NodePort
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Service
     policies.kyverno.io/description: >-
       A Kubernetes service of type NodePort uses a host port to receive traffic from 
       any source. A 'NetworkPolicy' resource cannot be used to control traffic to host ports. 

--- a/content/en/policies/other/add_labels.md
+++ b/content/en/policies/other/add_labels.md
@@ -2,6 +2,7 @@
 title: "Add Labels"
 category: Sample
 version: 
+subject: Label
 policyType: "mutate"
 description: >
     Simple mutation which adds a label `foo=bar` to different resource kinds.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Add Labels
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Label
     policies.kyverno.io/description: >-
       Simple mutation which adds a label `foo=bar` to different resource kinds.
 spec:

--- a/content/en/policies/other/add_nodeSelector.md
+++ b/content/en/policies/other/add_nodeSelector.md
@@ -2,6 +2,7 @@
 title: "Add nodeSelector"
 category: Sample
 version: 
+subject: Pod
 policyType: "mutate"
 description: >
     Adds the nodeSelector field to a Pod spec.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Add nodeSelector
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Adds the nodeSelector field to a Pod spec.
 spec:

--- a/content/en/policies/other/add_volume_deployment.md
+++ b/content/en/policies/other/add_volume_deployment.md
@@ -2,6 +2,7 @@
 title: "Add Volume to Deployment"
 category: Sample
 version: 
+subject: Deployment, Volume
 policyType: "mutate"
 description: >
     Sample policy to add a volume and volumeMount to a Deployment resource. This checks for the presence of an annotation called "vault.k8s.corp.net/inject=enabled" and adds an emptyDir volume using the memory medium.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Add Volume to Deployment
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Deployment, Volume
     policies.kyverno.io/description: >-
       Sample policy to add a volume and volumeMount to a Deployment resource. This checks for the presence of an annotation called
       "vault.k8s.corp.net/inject=enabled" and adds an emptyDir volume using the memory medium.

--- a/content/en/policies/other/block_updates_deletes.md
+++ b/content/en/policies/other/block_updates_deletes.md
@@ -2,6 +2,7 @@
 title: "Block Updates and Deletes"
 category: Sample
 version: 
+subject: RBAC
 policyType: "validate"
 description: >
     Kubernetes RBAC allows for controls on kinds of resources or those with specific names. This policy restricts updates and deletes to any resource that contains the label `protected="true"` unless by a cluster-admin and thus functions as a more granular option to Kubernetes RBAC. 
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Block Updates and Deletes
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: RBAC
     policies.kyverno.io/description: >-
       Kubernetes RBAC allows for controls on kinds of resources or those
       with specific names. This policy restricts updates and deletes to any

--- a/content/en/policies/other/create_pod_antiaffinity.md
+++ b/content/en/policies/other/create_pod_antiaffinity.md
@@ -2,6 +2,7 @@
 title: "Add Pod Anti-Affinity"
 category: Sample
 version: 
+subject: Deployment, Pod
 policyType: "mutate"
 description: >
     Sample policy to add Pod anti-affinity
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Add Pod Anti-Affinity
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Deployment, Pod
     policies.kyverno.io/description: >-
       Sample policy to add Pod anti-affinity
 spec:

--- a/content/en/policies/other/disallow_localhost_services.md
+++ b/content/en/policies/other/disallow_localhost_services.md
@@ -2,6 +2,7 @@
 title: "Disallow Localhost ExternalName Services"
 category: Sample
 version: 
+subject: Service
 policyType: "validate"
 description: >
     A Service of type ExternalName which points back to localhost can potentially be used to exploit vulnerabilities in some Ingress controllers. This sample policy blocks Services of type ExternalName if the externalName field refers to localhost.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Disallow Localhost ExternalName Services
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Service
     policies.kyverno.io/description: >-
       A Service of type ExternalName which points back to localhost can potentially be used to exploit
       vulnerabilities in some Ingress controllers. This sample policy blocks Services of type ExternalName

--- a/content/en/policies/other/disallow_secrets_from_env_vars.md
+++ b/content/en/policies/other/disallow_secrets_from_env_vars.md
@@ -2,6 +2,7 @@
 title: "Disallow Secrets from Env Vars"
 category: Sample
 version: 
+subject: Pod, Secret
 policyType: "validate"
 description: >
     Sample policy to disallow using secrets from environment variables  which are visible in resource definitions. 
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Disallow Secrets from Env Vars
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod, Secret
     policies.kyverno.io/description: >-
       Sample policy to disallow using secrets from environment variables 
       which are visible in resource definitions. 

--- a/content/en/policies/other/ensure_probes_different.md
+++ b/content/en/policies/other/ensure_probes_different.md
@@ -2,6 +2,7 @@
 title: "Validate Probes"
 category: Sample
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Sample policy to check that liveness and readiness probes are not set to the same values.
@@ -21,6 +22,7 @@ metadata:
     policies.kyverno.io/title: Validate Probes
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Sample policy to check that liveness and readiness probes are not set to the same values.
 spec:

--- a/content/en/policies/other/exclude_namespaces_dynamically.md
+++ b/content/en/policies/other/exclude_namespaces_dynamically.md
@@ -2,6 +2,7 @@
 title: "Exclude Namespaces Dynamically"
 category: Sample
 version: 
+subject: Namespace, Pod
 policyType: "validate"
 description: >
     Policy which illustrates how to dynamically look up an allow list of Namespaces from a ConfigMap where the ConfigMap stores an array of strings. This policy validates that any Pods created outside of the list of Namespaces have the label `foo` applied.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Exclude Namespaces Dynamically
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Namespace, Pod
     policies.kyverno.io/description: >-
       Policy which illustrates how to dynamically look up an allow list of Namespaces from a ConfigMap
       where the ConfigMap stores an array of strings. This policy validates that any Pods created

--- a/content/en/policies/other/imagepullpolicy-always.md
+++ b/content/en/policies/other/imagepullpolicy-always.md
@@ -2,6 +2,7 @@
 title: "Set imagePullPolicy"
 category: Sample
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Sample policy that sets imagePullPolicy to "Always" when the "latest" tag is used.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Set imagePullPolicy
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Sample policy that sets imagePullPolicy to "Always" when the "latest" tag is used.
 spec:

--- a/content/en/policies/other/inject_sidecar_deployment.md
+++ b/content/en/policies/other/inject_sidecar_deployment.md
@@ -2,6 +2,7 @@
 title: "Inject Sidecar Container"
 category: Sample
 version: 
+subject: Pod
 policyType: "mutate"
 description: >
     Sample policy that injects a sidecar container into Pods that match an annotation.  
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Inject Sidecar Container
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Sample policy that injects a sidecar container into Pods that match an annotation.  
 spec:

--- a/content/en/policies/other/require_deployments_have_multiple_replicas.md
+++ b/content/en/policies/other/require_deployments_have_multiple_replicas.md
@@ -2,6 +2,7 @@
 title: "Require Multiple Replicas"
 category: Sample
 version: 
+subject: Deployment
 policyType: "validate"
 description: >
     Sample policy that requires more than one replica for deployments.    
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Require Multiple Replicas
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Deployment
     policies.kyverno.io/description: >-
       Sample policy that requires more than one replica for deployments.    
 spec:

--- a/content/en/policies/other/require_image_checksum.md
+++ b/content/en/policies/other/require_image_checksum.md
@@ -2,6 +2,7 @@
 title: "Require Images Use Checksums"
 category: Sample
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Use of a SHA checksum when pulling an image is often preferable because tags are mutable and can be overwritten. This policy checks to ensure that all images use SHA checksums rather than tags.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Require Images Use Checksums
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Use of a SHA checksum when pulling an image is often preferable because tags
       are mutable and can be overwritten. This policy checks to ensure that all images

--- a/content/en/policies/other/restrict_annotations.md
+++ b/content/en/policies/other/restrict_annotations.md
@@ -2,6 +2,7 @@
 title: "Restrict Annotations"
 category: Sample
 version: 1.3.0
+subject: Pod, Annotation
 policyType: "validate"
 description: >
     This example policy prevents the use of an annotation beginning with a common key name (in this case "fluxcd.io/"). This can be useful to ensure users either don't set reserved annotations or to force them to use a newer version of an annotation.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Restrict Annotations
     policies.kyverno.io/category: Sample
     policies.kyverno.io/minversion: 1.3.0
+    policies.kyverno.io/subject: Pod, Annotation
     policies.kyverno.io/description: >-
       This example policy prevents the use of an annotation beginning with a common
       key name (in this case "fluxcd.io/"). This can be useful to ensure users either

--- a/content/en/policies/other/restrict_automount_sa_token.md
+++ b/content/en/policies/other/restrict_automount_sa_token.md
@@ -2,6 +2,7 @@
 title: "Restrict Auto-Mount of Service Account Tokens"
 category: Sample
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Kubernetes automatically mounts service account credentials in each pod.  The service account may be assigned roles allowing pods to access API resources.  To restrict access, opt out of auto-mounting tokens by setting  automountServiceAccountToken to false.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Restrict Auto-Mount of Service Account Tokens
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Kubernetes automatically mounts service account credentials in each pod. 
       The service account may be assigned roles allowing pods to access API resources. 

--- a/content/en/policies/other/restrict_controlplane_scheduling.md
+++ b/content/en/policies/other/restrict_controlplane_scheduling.md
@@ -2,6 +2,7 @@
 title: "Restrict control plane scheduling"
 category: Sample
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     This policy prevents users from setting a toleration in a Pod spec which allows running on control plane nodes with the taint key "node-role.kubernetes.io/master".   
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Restrict control plane scheduling
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       This policy prevents users from setting a toleration
       in a Pod spec which allows running on control plane nodes

--- a/content/en/policies/other/restrict_ingress_classes.md
+++ b/content/en/policies/other/restrict_ingress_classes.md
@@ -2,6 +2,7 @@
 title: "Restrict Ingress Classes"
 category: Sample
 version: 
+subject: Ingress
 policyType: "validate"
 description: >
     It can be useful to restrict Ingress resources to a set of known ingress classes  that are allowed in the cluster. You can customize this policy to allow ingress  classes that are configured in the cluster.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Restrict Ingress Classes
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Ingress
     policies.kyverno.io/description: >-
       It can be useful to restrict Ingress resources to a set of known ingress classes 
       that are allowed in the cluster. You can customize this policy to allow ingress 

--- a/content/en/policies/other/restrict_ingress_host.md
+++ b/content/en/policies/other/restrict_ingress_host.md
@@ -2,6 +2,7 @@
 title: "Unique Ingress Host"
 category: Sample
 version: 1.3.2
+subject: Ingress
 policyType: "validate"
 description: >
     Checks an incoming Ingress resource to ensure its hosts are unique to the cluster.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Unique Ingress Host
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Ingress
     policies.kyverno.io/minversion: 1.3.2
     policies.kyverno.io/description: >-
       Checks an incoming Ingress resource to ensure its hosts are unique to the cluster.

--- a/content/en/policies/other/restrict_loadbalancer.md
+++ b/content/en/policies/other/restrict_loadbalancer.md
@@ -2,6 +2,7 @@
 title: "Disallow Service Type LoadBalancer"
 category: Sample
 version: 
+subject: Service
 policyType: "validate"
 description: >
     Sample policy to restrict use of Service type LoadBalancer.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Disallow Service Type LoadBalancer
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Service
     policies.kyverno.io/description: >-
       Sample policy to restrict use of Service type LoadBalancer.
 spec:

--- a/content/en/policies/other/restrict_node_label_changes.md
+++ b/content/en/policies/other/restrict_node_label_changes.md
@@ -2,6 +2,7 @@
 title: "Restrict node label changes"
 category: Sample
 version: 
+subject: Node, Label
 policyType: "validate"
 description: >
     This policy prevents changes or deletions to label called `foo` on cluster nodes. Use of this policy requires removal of the Node resource filter in the Kyverno ConfigMap ([Node,*,*]). Due to Kubernetes CVE-2021-25735, this policy requires, at minimum, one of the following versions of Kubernetes: v1.18.18, v1.19.10, v1.20.6, or v1.21.0.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Restrict node label changes
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Node, Label
     policies.kyverno.io/description: >-
       This policy prevents changes or deletions to label called `foo` on
       cluster nodes. Use of this policy requires removal of the Node resource filter

--- a/content/en/policies/other/restrict_node_selection.md
+++ b/content/en/policies/other/restrict_node_selection.md
@@ -2,6 +2,7 @@
 title: "Restrict node selection"
 category: Sample
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     This policy prevents users from targeting specific nodes for scheduling of Pods by prohibiting the use of the `nodeSelector` and `nodeName` fields in a Pod spec.     
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Restrict node selection
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       This policy prevents users from targeting specific nodes
       for scheduling of Pods by prohibiting the use of the `nodeSelector`

--- a/content/en/policies/other/restrict_pod_count_per_node.md
+++ b/content/en/policies/other/restrict_pod_count_per_node.md
@@ -2,6 +2,7 @@
 title: "Restrict Pod Count per Node"
 category: Sample
 version: 1.3.2
+subject: Pod
 policyType: "validate"
 description: >
     Sample policy to restrict pod count on node 'minikube' to be no more than 10.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Restrict Pod Count per Node
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/minversion: 1.3.2
     policies.kyverno.io/description: >-
       Sample policy to restrict pod count on node 'minikube' to be no more than 10.

--- a/content/en/policies/other/restrict_service_account.md
+++ b/content/en/policies/other/restrict_service_account.md
@@ -2,6 +2,7 @@
 title: "Restrict Service Account"
 category: Sample
 version: 1.3.5
+subject: Pod
 policyType: "validate"
 description: >
     Restrict Pod resources to use a known service account can be useful to ensure workload identity. This policy uses a ConfigMap resource as an external data source to map service accounts to images. Example: 'sa-name: ["registry/image-name"]'
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Restrict Service Account
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/minversion: 1.3.5
     policies.kyverno.io/description: >-
       Restrict Pod resources to use a known service account can be useful to

--- a/content/en/policies/other/restrict_usergroup_fsgroup_id.md
+++ b/content/en/policies/other/restrict_usergroup_fsgroup_id.md
@@ -2,6 +2,7 @@
 title: "Validate User ID, Group ID, and FS Group"
 category: Sample
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     All processes inside the pod can be made to run with specific user and groupID  by setting 'runAsUser' and 'runAsGroup' respectively. 'fsGroup' can be specified  to make sure any file created in the volume with have the specified groupID.  These options can be used to validate the IDs used for user and group.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Validate User ID, Group ID, and FS Group 
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       All processes inside the pod can be made to run with specific user and groupID 
       by setting 'runAsUser' and 'runAsGroup' respectively. 'fsGroup' can be specified 

--- a/content/en/policies/other/spread_pods_across_topology.md
+++ b/content/en/policies/other/spread_pods_across_topology.md
@@ -2,6 +2,7 @@
 title: "Spread Pods Across Nodes"
 category: Sample
 version: 
+subject: Deployment, Pod
 policyType: "mutate"
 description: >
     Sample policy to spread pods matching a label across nodes.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Spread Pods Across Nodes 
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Deployment, Pod
     policies.kyverno.io/description: >-
       Sample policy to spread pods matching a label across nodes.
 spec:

--- a/content/en/policies/other/sync_secrets.md
+++ b/content/en/policies/other/sync_secrets.md
@@ -2,6 +2,7 @@
 title: "Sync Secrets"
 category: Sample
 version: 
+subject: Secret
 policyType: "generate"
 description: >
     Secrets like registry credentials often need to exist in multiple namespaces so pods there have access. This sample policy will copy a secret called "regcred" which exists in the default namespace to new namespaces when they are created. It will also push updates to the copied secrets should the source secret be changed.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Sync Secrets 
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Secret
     policies.kyverno.io/description: >-
       Secrets like registry credentials often need to exist in multiple
       namespaces so pods there have access. This sample policy will copy a

--- a/content/en/policies/pod-security/baseline/disallow-adding-capabilities/disallow-adding-capabilities.md
+++ b/content/en/policies/pod-security/baseline/disallow-adding-capabilities/disallow-adding-capabilities.md
@@ -2,6 +2,7 @@
 title: "Disallow Add Capabilities"
 category: Pod Security Standards (Baseline)
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Capabilities permit privileged actions without giving full root access. Adding capabilities beyond the default set must not be allowed.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Capabilities permit privileged actions without giving full root access.
       Adding capabilities beyond the default set must not be allowed.

--- a/content/en/policies/pod-security/baseline/disallow-host-ipc/disallow-host-ipc.md
+++ b/content/en/policies/pod-security/baseline/disallow-host-ipc/disallow-host-ipc.md
@@ -2,6 +2,7 @@
 title: "Disallow Host Ipc"
 category: Pod Security Standards (Baseline)
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Sharing the host's PID namespace allows visibility of process on the host, potentially exposing process information. Sharing the host's IPC namespace allows the container process to communicate with processes on the host. To avoid pod container from having visibility to host process space, validate that 'hostPID' and 'hostIPC' are set to 'false'.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description:
       Sharing the host's PID namespace allows visibility of process
       on the host, potentially exposing process information. Sharing the host's IPC namespace allows

--- a/content/en/policies/pod-security/baseline/disallow-host-namespaces/disallow-host-namespaces.md
+++ b/content/en/policies/pod-security/baseline/disallow-host-namespaces/disallow-host-namespaces.md
@@ -2,6 +2,7 @@
 title: "Disallow Host Namespaces"
 category: Pod Security Standards (Baseline)
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Host namespaces (Process ID namespace, Inter-Process Communication namespace, and network namespace) allow access to shared information and can be used to elevate privileges. Pods should not be allowed access to host namespaces.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Host namespaces (Process ID namespace, Inter-Process Communication namespace, and
       network namespace) allow access to shared information and can be used to elevate

--- a/content/en/policies/pod-security/baseline/disallow-host-path/disallow-host-path.md
+++ b/content/en/policies/pod-security/baseline/disallow-host-path/disallow-host-path.md
@@ -2,6 +2,7 @@
 title: "Disallow Host Path"
 category: Pod Security Standards (Baseline)
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     HostPath volumes let pods use host directories and volumes in containers. Using host resources can be used to access shared data or escalate privileges and should not be allowed.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       HostPath volumes let pods use host directories and volumes in containers.
       Using host resources can be used to access shared data or escalate privileges

--- a/content/en/policies/pod-security/baseline/disallow-host-ports/disallow-host-ports.md
+++ b/content/en/policies/pod-security/baseline/disallow-host-ports/disallow-host-ports.md
@@ -2,6 +2,7 @@
 title: "Disallow Host Ports"
 category: Pod Security Standards (Baseline)
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Access to host ports allows potential snooping of network traffic and should not be allowed, or at minimum restricted to a known list.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Access to host ports allows potential snooping of network traffic and should not be
       allowed, or at minimum restricted to a known list.

--- a/content/en/policies/pod-security/baseline/disallow-privileged-containers/disallow-privileged-containers.md
+++ b/content/en/policies/pod-security/baseline/disallow-privileged-containers/disallow-privileged-containers.md
@@ -2,6 +2,7 @@
 title: "Disallow Privileged Containers"
 category: Pod Security Standards (Baseline)
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Privileged mode disables most security mechanisms and must not be allowed.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Privileged mode disables most security mechanisms and must not be allowed.
 spec:

--- a/content/en/policies/pod-security/baseline/disallow-proc-mount/disallow-proc-mount.md
+++ b/content/en/policies/pod-security/baseline/disallow-proc-mount/disallow-proc-mount.md
@@ -2,6 +2,7 @@
 title: "Require Default Proc Mount"
 category: Pod Security Standards (Baseline)
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     The default /proc masks are set up to reduce attack surface and should be required.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       The default /proc masks are set up to reduce attack surface and should be required.
 spec:

--- a/content/en/policies/pod-security/baseline/disallow-selinux/disallow-selinux.md
+++ b/content/en/policies/pod-security/baseline/disallow-selinux/disallow-selinux.md
@@ -2,6 +2,7 @@
 title: "Disallow SELinux"
 category: Pod Security Standards (Baseline)
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     SELinux options can be used to escalate privileges and should not be allowed.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Disallow SELinux
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       SELinux options can be used to escalate privileges and should not be allowed.
 spec:

--- a/content/en/policies/pod-security/baseline/restrict-apparmor-profiles/restrict-apparmor-profiles.md
+++ b/content/en/policies/pod-security/baseline/restrict-apparmor-profiles/restrict-apparmor-profiles.md
@@ -2,6 +2,7 @@
 title: "Restrict AppArmor"
 category: Pod Security Standards (Baseline)
 version: 1.3.0
+subject: Pod, Annotation
 policyType: "validate"
 description: >
     On supported hosts, the 'runtime/default' AppArmor profile is applied by default.  The default policy should prevent overriding or disabling the policy, or restrict  overrides to an allowed set of profiles.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Restrict AppArmor
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod, Annotation
     policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/description: >-
       On supported hosts, the 'runtime/default' AppArmor profile is applied by default. 

--- a/content/en/policies/pod-security/baseline/restrict-sysctls/restrict-sysctls.md
+++ b/content/en/policies/pod-security/baseline/restrict-sysctls/restrict-sysctls.md
@@ -2,6 +2,7 @@
 title: "Restrict Sysctls"
 category: Pod Security Standards (Baseline)
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Sysctls can disable security mechanisms or affect all containers on a host, and should be disallowed except for an allowed "safe" subset. A sysctl is considered safe if it is namespaced in the container or the Pod, and it is isolated from other Pods or processes on the same Node.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Sysctls can disable security mechanisms or affect all containers on a
       host, and should be disallowed except for an allowed "safe" subset. A

--- a/content/en/policies/pod-security/restricted/deny-privilege-escalation/deny-privilege-escalation.md
+++ b/content/en/policies/pod-security/restricted/deny-privilege-escalation/deny-privilege-escalation.md
@@ -2,6 +2,7 @@
 title: "Deny Privilege Escalation"
 category: Pod Security Standards (Restricted)
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Privilege escalation, such as via set-user-ID or set-group-ID file mode, should not be allowed.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Privilege escalation, such as via set-user-ID or set-group-ID file mode, should not be allowed.
 spec:

--- a/content/en/policies/pod-security/restricted/require-non-root-groups/require-non-root-groups.md
+++ b/content/en/policies/pod-security/restricted/require-non-root-groups/require-non-root-groups.md
@@ -2,6 +2,7 @@
 title: "Require Non Root Groups"
 category: Pod Security Standards (Restricted)
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Containers should be forbidden from running with a root primary or supplementary GID.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Containers should be forbidden from running with a root primary or supplementary GID.
 spec:

--- a/content/en/policies/pod-security/restricted/require-run-as-nonroot/require-run-as-nonroot.md
+++ b/content/en/policies/pod-security/restricted/require-run-as-nonroot/require-run-as-nonroot.md
@@ -2,6 +2,7 @@
 title: "Require Run As Non Root"
 category: Pod Security Standards (Restricted)
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     Containers must be required to run as non-root users.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: Containers must be required to run as non-root users.
 spec:
   background: true

--- a/content/en/policies/pod-security/restricted/restrict-seccomp/restrict-seccomp.md
+++ b/content/en/policies/pod-security/restricted/restrict-seccomp/restrict-seccomp.md
@@ -2,6 +2,7 @@
 title: "Restrict Seccomp"
 category: Pod Security Standards (Restricted)
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     The runtime default seccomp profile must be required, or only specific additional profiles should be allowed.
@@ -19,6 +20,7 @@ metadata:
     policies.kyverno.io/title: Restrict Seccomp
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       The runtime default seccomp profile must be required, or only specific
       additional profiles should be allowed.

--- a/content/en/policies/pod-security/restricted/restrict-volume-types/restrict-volume-types.md
+++ b/content/en/policies/pod-security/restricted/restrict-volume-types/restrict-volume-types.md
@@ -2,6 +2,7 @@
 title: "Restrict Volume Types"
 category: Pod Security Standards (Restricted)
 version: 
+subject: Pod
 policyType: "validate"
 description: >
     In addition to restricting HostPath volumes, the restricted pod security profile limits usage of non-core volume types to those defined through PersistentVolumes.
@@ -18,6 +19,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       In addition to restricting HostPath volumes, the restricted pod security profile
       limits usage of non-core volume types to those defined through PersistentVolumes.

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -10,7 +10,8 @@
       "policy" $policy
       "category" .Params.category 
       "version" .Params.version
-      "filters" (printf "%s::%s::%s" $policy .Params.category .Params.version)
+      "subject" .Params.subject
+      "filters" (printf "%s::%s::%s" $policy .Params.category .Params.version .Params.subject)
     ) -}}
   {{- end }}
 {{- end -}}

--- a/render/template.go
+++ b/render/template.go
@@ -5,6 +5,7 @@ var policyTemplate = `---
 title: "{{ .Title }}"
 category: {{ index $annotations "policies.kyverno.io/category" }}
 version: {{ index $annotations "policies.kyverno.io/minversion" }}
+subject: {{ index $annotations "policies.kyverno.io/subject" }}
 policyType: "{{ .Type }}"
 description: >
     {{ index $annotations "policies.kyverno.io/description" }}


### PR DESCRIPTION
Adds a new "Subject" filter option to the policy page allowing users to filter for policies based upon the subject of the policy.