### PR TITLE
Drop down nav bar for mobile

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,0 +1,12 @@
+.td-navbar {
+  min-height: auto;
+}
+
+.navbar-nav {
+  @media (max-width: 992px) {
+    font-size: .875rem;
+    .dropdown {
+      min-width: inherit;
+    }
+  }
+}

--- a/layouts/partials/navbar-version-selector.html
+++ b/layouts/partials/navbar-version-selector.html
@@ -1,0 +1,8 @@
+<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+	{{ .Site.Params.version_menu }}
+</a>
+<div class="dropdown-menu dropdown-menu-md-right dropdown-menu-lg-left" aria-labelledby="navbarDropdownMenuLink">
+	{{ range .Site.Params.versions }}
+	<a class="dropdown-item" href="{{ .url }}">{{ .version }}</a>
+	{{ end }}
+</div>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,16 +1,20 @@
 {{ $cover := .HasShortcode "blocks/cover" }}
 
-<nav class="js-navbar-scroll navbar navbar-expand navbar-dark {{ if $cover}} td-navbar-cover {{ end }}flex-column flex-md-row td-navbar" style="top: 40px;">
+<nav class="js-navbar-scroll navbar navbar-expand-md navbar-dark {{ if $cover}} td-navbar-cover {{ end }} td-navbar py-2" style="top: 40px;">
 	<a href="https://github.com/kyverno/kyverno/" target="_blank" class="d-block fixed-top px-3 py-2 bg-secondary text-center text-bold text-dark">⭐️ If you like Kyverno, give it a star on GitHub! ⭐️</a>
 
 	<a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
 		<span class="navbar-logo">{{ with resources.Get "icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }} {{ end }}</span><span class="brand-name text-uppercase font-weight-bold">{{ .Site.Title }}</span>
 	</a>
-	<div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
-		<ul class="navbar-nav mt-2 mt-lg-0">
+	<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_navbar"
+		aria-controls="main_navbar" aria-expanded="false" aria-label="Toggle navigation">
+		<span class="navbar-toggler-icon"></span>
+	</button>
+	<div class="collapse navbar-collapse ml-md-auto" id="main_navbar">
+		<ul class="navbar-nav ml-auto pt-4 pt-md-0 my-2 my-md-1">
 			{{ $p := . }}
 			{{ range .Site.Menus.main }}
-			<li class="nav-item mr-4 mb-2 mb-lg-0">
+			<li class="nav-item mr-2 mr-lg-4 mt-1 mt-lg-0">
 				{{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) }}
 				{{ with .Page }}
 				{{ $active = or $active ( $.IsDescendant .)  }}
@@ -20,13 +24,13 @@
 				<a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}" {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}><span{{if $active }} class="active"{{end}}>{{ .Name }}</span></a>
 			</li>
 			{{ end }}
-			{{ if  .Site.Params.versions }}
-      <li class="nav-item dropdown d-none d-lg-block">
+			{{ if .Site.Params.versions }}
+      <li class="nav-item dropdown mt-1 mt-lg-0">
         {{ partial "navbar-version-selector.html" . }}
 			</li>
 			{{ end }}
 			{{ if  (gt (len .Site.Home.Translations) 0) }}
-			<li class="nav-item dropdown d-none d-lg-block">
+			<li class="nav-item dropdown mt-1 mt-lg-0">
 				{{ partial "navbar-lang-selector.html" . }}
 			</li>
 			{{ end }}


### PR DESCRIPTION
Fixes #238 
- For Desktop, it is as it is before
- For mobile screens, a drop-down menu appears when you click on the button on the right margin that shows the entire nav-bar including a further drop-down for the versions

### For Desktop:
Before | After
-------- | ---------
![image](https://user-images.githubusercontent.com/55556994/129587887-18bef9a6-db2c-4649-9a9a-28e2577029dc.png) | ![image](https://user-images.githubusercontent.com/55556994/129588019-81c951f4-2660-4b4f-b5ea-773453d4ce36.png)

### For Mobile:
| Situation |  Screen
-------- | ---------
Idle | <img src="https://user-images.githubusercontent.com/55556994/129589376-0fc90833-6c1b-460f-b858-7e5957962f5f.png" height=300>
Clicking on the expand button |  <img src="https://user-images.githubusercontent.com/55556994/129588496-8f771835-1f27-45ad-a1e1-bad7e0b1508d.png" height=300>
Drop-down for versions | <img src="https://user-images.githubusercontent.com/55556994/129589459-c306636e-5db8-40ca-a403-f2d3936911c0.png" height=300>


