### PR TITLE
Video thumbnails made responsive

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -60,7 +60,8 @@ footer {
 
 .videos {
   display: flex;
+  flex-wrap: wrap;
 }
 .videos > .video {
-  margin-right: 1.5rem;
+  margin: 1rem;
 }


### PR DESCRIPTION
As of now, the user has to scroll horizontally on mobile screens to view half of the videos which affects the UX of the website.
With this PR, all the videos will horizontally fit in the screen (if not enough to accommodate 2 videos horizontally, it would push the other one down)

The video thumbnails on the [resources page](https://kyverno.io/resources/) have been made responsive.

- Wrapped them inside a `flex-wrap`
- Margin set to 1 rem to adjust for all the devices

## Desktop
| Before | ![image](https://user-images.githubusercontent.com/55556994/130263246-26b9de1c-ae15-4719-955b-33f670bbbf2c.png) |
| -------- | --------- |
| After | ![image](https://user-images.githubusercontent.com/55556994/130263328-be6e883f-d33a-4fcb-a365-656720adf966.png) |

## Mobiles
| Device | Before | After |
| ------- | ------- | -------- |
| iPhone X | <img src="https://user-images.githubusercontent.com/55556994/130264226-8a676d0c-94c6-46b9-846f-8103aad60809.png" height=400> | <img src="https://user-images.githubusercontent.com/55556994/130264301-11f7ebbc-4f10-4fad-a507-4077ae2a9f49.png" height=400> |
| Pixel 2 | <img src="https://user-images.githubusercontent.com/55556994/130264563-4b517020-f935-4855-9cc9-0ebce4c74a1a.png" height=400> | <img src="https://user-images.githubusercontent.com/55556994/130264618-b518a6b0-96bf-4d2d-8bb3-d07bf0681a91.png" height=400> |


