### PR TITLE
updates install kyverno steps from release manifest

### DIFF
--- a/content/en/docs/Installation/_index.md
+++ b/content/en/docs/Installation/_index.md
@@ -76,7 +76,7 @@ If you'd rather deploy the manifest directly, simply apply the release file.
 This manifest path will always point to the latest main branch.
 
 ```sh
-kubectl create -f https://raw.githubusercontent.com/kyverno/kyverno/main/definitions/release/install.yaml
+kubectl create -f https://raw.githubusercontent.com/kyverno/kyverno/main/config/release/install.yaml
 ```
 
 You can also pull from a release branch to install the stable releases including release candidates.
@@ -145,7 +145,7 @@ Kyverno can automatically generate a new self-signed Certificate Authority (CA) 
 
 ```sh
 ## Install Kyverno
-kubectl create -f https://raw.githubusercontent.com/kyverno/kyverno/main/definitions/release/install.yaml
+kubectl create -f https://raw.githubusercontent.com/kyverno/kyverno/main/config/release/install.yaml
 ```
 
 {{% alert title="Note" color="info" %}}
@@ -264,7 +264,7 @@ This process has been automated for you with a simple script that generates a se
 You can now install Kyverno by downloading and updating `install.yaml`, or using the command below (assumes that the namespace is "kyverno"):
 
 ```sh
-kubectl create -f https://raw.githubusercontent.com/kyverno/kyverno/main/definitions/release/install.yaml
+kubectl create -f https://raw.githubusercontent.com/kyverno/kyverno/main/config/release/install.yaml
 ```
 
 ## Configuring Kyverno

--- a/content/en/docs/Introduction/_index.md
+++ b/content/en/docs/Introduction/_index.md
@@ -52,7 +52,7 @@ You have the option of installing Kyverno directly from the latest release manif
 To install Kyverno using the latest release manifest (which may be a pre-release):
 
 ```sh
-kubectl create -f https://raw.githubusercontent.com/kyverno/kyverno/main/definitions/release/install.yaml
+kubectl create -f https://raw.githubusercontent.com/kyverno/kyverno/main/config/release/install.yaml
 ```
 
 You can also install Kyverno using a Helm chart:


### PR DESCRIPTION
Currently installing kyverno from the release manifest using the steps from docs gives this error:
```
error: unable to read URL "https://raw.githubusercontent.com/kyverno/kyverno/main/definitions/release/install.yaml", server reported 404 Not Found, status code=404
```

This is because definitions folder doesn't exist anymore and the install.yaml lies in config/release, this PR updates that

 Signed-off-by: Mritunjay Sharma <mritunjaysharma394@gmail.com>