### PR TITLE
update: signing and sbom as per release 1.5.1

### DIFF
--- a/content/en/docs/Installation/_index.md
+++ b/content/en/docs/Installation/_index.md
@@ -91,44 +91,25 @@ Kyverno container images are signed using [Cosign](https://github.com/sigstore/c
 
 1. Install the [Cosign command line interface](https://github.com/sigstore/cosign#installation)
 
-2. Configure the Kyverno signature repository:
+2. Verify the image:
 
 ```sh
-export COSIGN_REPOSITORY=ghcr.io/kyverno/signatures
-```
-
-3. Verify the image:
-
-```sh
-cosign verify -key cosign.pub ghcr.io/kyverno/kyverno:latest
+cosign verify --key=cosign.pub ghcr.io/kyverno/kyverno:v1.5.1
 ```
 
 If the container image was properly signed, the output should be similar to:
 
 ```sh
-Verification for kyverno/kyverno:latest --
+Verification for ghcr.io/kyverno/kyverno:v1.5.1 --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - The signatures were verified against the specified public key
   - Any certificates were verified against the Fulcio roots.
-[{"critical":{"identity":{"docker-reference":"ghcr.io/kyverno/kyverno"},"image":{"docker-manifest-digest":"sha256:a847df12e2c1cab19af9d1bb34e599cb56cf57639c7d5c958a4bb568c1dad8f6"},"type":"cosign container image signature"},"optional":null}]
+
+[{"critical":{"identity":{"docker-reference":"ghcr.io/kyverno/kyverno"},"image":{"docker-manifest-digest":"sha256:f98818aca5e720aa72fb29b89efe98cf39f729c3a9e5e671a9959fc9e7e865fa"},"type":"cosign container image signature"},"optional":null}]
 ```
 
 All 3 of Kyverno images can be verified: `kyvernopre`, `kyverno`, and `kyverno-cli`.
-
-## Download the Software Bill of Materials
-
-An SBOM (Software Bill of Materials) in CycloneDX JSON format is published for each Kyverno release. To download the SBOM for a specific version, install the [Cosign command line interface](https://github.com/sigstore/cosign#installation) and run:
-
-```sh
-cosign download sbom ghcr.io/kyverno/sbom:latest
-```
-
-To save the SBOM to a file, run the following command:
-
-```sh
-cosign download sbom ghcr.io/kyverno/sbom:latest > kyverno.sbom.json
-```
 
 ## Customize the installation of Kyverno
 


### PR DESCRIPTION
Signed-off-by: ShubhamPalriwala <spalriwalau@gmail.com>

For the current release, we are unable to download the SBOM  hence we should remove it from the current release docs. It will be ready once v1.5.2 is released hence it is present as it is in our `main` branch.

In case of signing, as PR https://github.com/kyverno/kyverno/pull/2536 is added as 1.5.2 milestone, the current docs in main are misleading hence for an immediate fix, we can update it as to how it works in for v1.5.1