### PR TITLE
Release 1 6 0

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -54,6 +54,10 @@ id = ""
 # Add your release versions here
 
 [[params.versions]]
+  version = "v1.6.0"
+  url = "https://release-1-6-0.kyverno.io"
+
+[[params.versions]]
   version = "v1.5.0"
   url = "https://release-1-5-0.kyverno.io"
 

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -9,7 +9,7 @@ showLineNumbers = false
 
 # Menu title if your navbar has a versions selector to access old versions of your site.
 # This menu appears only if you have at least one [versions] set.
-version_menu = "main"
+version_menu = "1.6.0"
 
 # Flag used in the "version-banner" partial to decide whether to display a 
 # banner on every page indicating that this is an archived version of the docs.
@@ -19,11 +19,11 @@ archived_version = false
 # The version number for the version of the docs represented in this doc set.
 # Used in the "version-banner" partial to display a version number for the 
 # current doc set.
-version = "main"
+version = "1.6.0"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
-url_latest_version = "https://main.kyverno.io"
+url_latest_version = "https://release-1-6-0.kyverno.io"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 github_repo = "https://github.com/kyverno/website"


### PR DESCRIPTION
Config updates. Not sure why https://release-1-6-0.kyverno.io/ isn't working at this point. I thought it should after I created the subdomain. But these config file changes are needed anyhow.