### PR TITLE
Document imageData policies can also use private registries

### DIFF
--- a/content/en/docs/Writing policies/external-data-sources.md
+++ b/content/en/docs/Writing policies/external-data-sources.md
@@ -615,4 +615,6 @@ context:
       jmesPath: "to_string(sum(manifest.layers[*].size))"
 ```
 
+To access images stored on private registries, see [using private registries](/docs/writing-policies/verify-images#using-private-registries)
+
 For more examples of using an imageRegistry context, see the [samples page](/policies).


### PR DESCRIPTION
## Related issue #

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->
Brought up in Slack: https://kubernetes.slack.com/archives/CLGR9BJU9/p1650304196171389

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->
Provide link to how to define private registries for imageData policies.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [] I have inspected the website preview for accuracy.
- [] I have signed off my issue.
