### PR TITLE
Document imageData policies can also use private registries

### DIFF
--- a/content/en/docs/Writing policies/external-data-sources.md
+++ b/content/en/docs/Writing policies/external-data-sources.md
@@ -642,4 +642,6 @@ context:
       jmesPath: "to_string(sum(manifest.layers[*].size))"
 ```
 
+To access images stored on private registries, see [using private registries](/docs/writing-policies/verify-images#using-private-registries)
+
 For more examples of using an imageRegistry context, see the [samples page](/policies).


### PR DESCRIPTION
## Related issue #

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

This is a back port of #517 into 1.6 webpage.
