### PR TITLE
Fix missing hyphen (-) in doc

### DIFF
--- a/content/en/docs/Writing policies/match-exclude.md
+++ b/content/en/docs/Writing policies/match-exclude.md
@@ -300,16 +300,16 @@ Here is an example of a rule that matches all Pods excluding those created by us
 ```yaml
 spec:
   rules:
-    name: match-pods-except-cluster-admin
-    match:
-      any:
-      - resources:
-          kinds:
-          - Pod
-    exclude:
-      any:
-      - clusterRoles:
-        - cluster-admin
+    - name: match-pods-except-cluster-admin
+      match:
+        any:
+        - resources:
+            kinds:
+            - Pod
+      exclude:
+        any:
+        - clusterRoles:
+          - cluster-admin
 ```
 
 ### Exclude `kube-system` namespace
@@ -323,17 +323,17 @@ Exclusion of selected Namespaces by name is supported beginning in Kyverno 1.3.0
 ```yaml
 spec:
   rules:
-    name: match-pods-except-admin
-    match:
-      any:
-      - resources:
-          kinds:
-          - Pod
-    exclude:
-      any:
-      - resources:
-          namespaces:
-          - kube-system
+    - name: match-pods-except-admin
+      match:
+        any:
+        - resources:
+            kinds:
+            - Pod
+      exclude:
+        any:
+        - resources:
+            namespaces:
+            - kube-system
 ```
 
 ### Match a label and exclude users and roles


### PR DESCRIPTION
Signed-off-by: Tathagata Paul <tathagatapaul7@gmail.com>

## Related issue #

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes
Fix documentation for "match-exclude" where a hyphen (-) was missing
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [ ] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
