### PR TITLE
[1.7.0] Add docs on `items()` and `object_from_list()` JMESPath filters

### DIFF
--- a/content/en/docs/Writing policies/jmespath.md
+++ b/content/en/docs/Writing policies/jmespath.md
@@ -706,7 +706,7 @@ $ echo '{"team" : "apple" , "organization" : "banana" }' | k kyverno jp "items(@
 
 <br>
 
-Related filter to `items()` is its inverse, [`object_from_lists()`](#object_from_lists).
+Related filter to `items()` is its inverse, [`object_from_list()`](#object_from_list).
 
 <br>
 


### PR DESCRIPTION
## Related issue #

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->
Closes #529 
Closes #530 

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

* Adds documentation on new custom JMESPath filters `items()` and `object_from_list()`

Cherry pick to 1.7.0 branch is needed.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
