### PR TITLE
extract policy-type after spec declaration

### DIFF
--- a/render/render.go
+++ b/render/render.go
@@ -47,11 +47,13 @@ func getPolicyType(yaml string) string {
 	validate := "validate"
 	verifyImages := "verifyImages"
 
-	if stringContains(yaml, generate) {
+	newYAML := strings.Split(yaml, "spec:")[1]
+
+	if stringContains(newYAML, generate) {
 		return generate
-	} else if stringContains(yaml, mutate) {
+	} else if stringContains(newYAML, mutate) {
 		return mutate
-	} else if stringContains(yaml, validate) {
+	} else if stringContains(newYAML, validate) {
 		return validate
 	} else {
 		return verifyImages


### PR DESCRIPTION
Signed-off-by: weru <fromweru@gmail.com>

## Related issue #547 
Closes #547 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

@chipzoller 

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

We were querying the entire policy contents to determine what the policy type is. This way, if the name of a policy type e.g `generate` was found somewhere before the spec declaration, that policy would be assigned that type.

Obviously, it's more fool-proof to query for the type after the spec declaration i.e  after👇🏼 

```yaml
...
spec: 
...
```

I have render the policies locally and the issue seems to be fixed with no regressions

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
