### PR TITLE
modified autogen.md and mutate.md

### DIFF
--- a/content/en/docs/Writing policies/autogen.md
+++ b/content/en/docs/Writing policies/autogen.md
@@ -108,11 +108,17 @@ To disable auto-generating rules for Pod controllers set `pod-policies.kyverno.i
 
 When disabling auto-generation rules for select Pod controllers, Kyverno still applies policy matching on Pods to those spawned by those controllers. To exempt these Pods, use [preconditions](/docs/writing-policies/preconditions/) with an expression similar to the below which may allow Pods created by a Job controller to pass.
 
+
 ```yaml
 - key: Job
   operator: AnyNotIn
   value: "{{ request.object.metadata.ownerReferences[].kind }}"
 ```
+
+{{% alert title="Note" color="Info" %}}
+`Auto-gen rules` is not enabled for patchesJson6902 mutation rules.
+{{% /alert %}}
+
 
 ## Exclusion by Metadata
 

--- a/content/en/docs/Writing policies/mutate.md
+++ b/content/en/docs/Writing policies/mutate.md
@@ -48,7 +48,7 @@ With Kyverno, the `add` and `replace` have the same behavior (i.e., both operati
 
 The `patchesJson6902` method can be useful when a specific mutation is needed which cannot be performed by `patchesStrategicMerge`. For example, when needing to mutate a specific object within an array, the index can be specified as part of a `patchesJson6902` mutation rule.
 
-One distinction between this and other mutation methods is that `patchesJson6902` does not support the use of conditional anchors. Use [preconditions](/docs/writing-policies/preconditions/) instead. Also, mutations using `patchesJson6902` to Pods directly is not supported as the rules are not converted to higher-level controllers such as Deployments and StatefulSets through the use of the [auto-gen feature](/docs/writing-policies/autogen/). Therefore, when writing such mutation rules for Pods, it may be necessary to create multiple rules to cover all relevant Pod controllers.
+One distinction between this and other mutation methods is that `patchesJson6902` does not support the use of conditional anchors. Use [preconditions](/docs/writing-policies/preconditions/) instead. Also, mutations using `patchesJson6902` to Pods directly is supported but one cannot get the autogen rules that also mutate pod templates in Controller resources. Therefore, when writing such mutation rules for Pods, it may be necessary to create multiple rules to cover all relevant Pod controllers.
 
 This patch policy adds, or replaces, entries in a ConfigMap with the name `config-game` in any namespace.
 


### PR DESCRIPTION
Signed-off-by: hitarth01 <srivastavahitarth19@gmail.com>

## Related issue #
Fixes issue #629
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes
Added a note to `docs/writing-policies/autogen/` that auto-gen rules is not enabled for patchesJson6902 mutation rules since previously it did not note the patchesJson6902 exclusion. 
Also, modified the line `mutations using patchesJson6902 to Pods directly is not supported` since one can mutate pods directly with the json6902 patch, one just cannot get the auto-gen rules that also mutate pod templates in Controller resources.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
