### PR TITLE
fix: remove --devel from tracing tutorials

### DIFF
--- a/content/en/docs/Tracing/jaeger-walkthrough.md
+++ b/content/en/docs/Tracing/jaeger-walkthrough.md
@@ -100,7 +100,7 @@ We can deploy Kyverno using Helm with the following command:
 
 ```shell
 helm upgrade --install kyverno --namespace kyverno --create-namespace --wait \
-  --devel --repo https://kyverno.github.io/kyverno kyverno \
+  --repo https://kyverno.github.io/kyverno kyverno \
   --values - <<EOF
 # kyverno controller
 extraArgs:
@@ -131,7 +131,7 @@ We are going to deploy the `kyverno-policies` Helm chart (with the `Baseline` pr
 
 ```shell
 helm upgrade --install kyverno-policies --namespace kyverno --create-namespace --wait \
-  --devel --repo https://kyverno.github.io/kyverno kyverno-policies \
+  --repo https://kyverno.github.io/kyverno kyverno-policies \
   --values - <<EOF
 validationFailureAction: Enforce
 EOF

--- a/content/en/docs/Tracing/tempo-walkthrough.md
+++ b/content/en/docs/Tracing/tempo-walkthrough.md
@@ -138,7 +138,7 @@ We can deploy Kyverno using Helm with the following command:
 
 ```shell
 helm upgrade --install kyverno --namespace kyverno --create-namespace --wait \
-  --devel --repo https://kyverno.github.io/kyverno kyverno \
+  --repo https://kyverno.github.io/kyverno kyverno \
   --values - <<EOF
 # kyverno controller
 extraArgs:
@@ -169,7 +169,7 @@ We are going to deploy the `kyverno-policies` Helm chart (with the `Baseline` pr
 
 ```shell
 helm upgrade --install kyverno-policies --namespace kyverno --create-namespace --wait \
-  --devel --repo https://kyverno.github.io/kyverno kyverno-policies \
+  --repo https://kyverno.github.io/kyverno kyverno-policies \
   --values - <<EOF
 validationFailureAction: Enforce
 EOF


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

This PR removes `--devel` from tracing tutorials.

## Related issue #

Closes #746 