### PR TITLE
Add Troubleshooting section for high resource usage on AKS 

### DIFF
--- a/content/en/docs/Troubleshooting/_index.md
+++ b/content/en/docs/Troubleshooting/_index.md
@@ -98,7 +98,7 @@ After gathering this information, [create an issue](https://github.com/kyverno/k
 
 **Symptom**: I'm using AKS and Kyverno is using too much memory or CPU
 
-**Solution**: On AKS the kyverno webhooks will be mutated by the [Admissions Enforcer](https://learn.microsoft.com/en-us/azure/aks/faq#can-admission-controller-webhooks-impact-kube-system-and-internal-aks-namespaces) that can lead to an endless update loop. To prevent that behaviour, you can set the annotation `"admissions.enforcer/disabled": true` to all kyverno webhooks. When installing via Helm, you can change the annotations with `config.webhookAnnotations`.
+**Solution**: On AKS the kyverno webhooks will be mutated by the AKS [Admissions Enforcer](https://learn.microsoft.com/en-us/azure/aks/faq#can-admission-controller-webhooks-impact-kube-system-and-internal-aks-namespaces) Plugin, that can lead to an endless update loop. To prevent that behaviour, you can set the annotation `"admissions.enforcer/disabled": true` to all kyverno webhooks. When installing via Helm, you can add the annotation with `config.webhookAnnotations`.
 
 ## Kyverno is slow to respond
 

--- a/content/en/docs/Troubleshooting/_index.md
+++ b/content/en/docs/Troubleshooting/_index.md
@@ -96,6 +96,10 @@ kubectl get cm,secret -A | wc -l
 
 After gathering this information, [create an issue](https://github.com/kyverno/kyverno/issues/new/choose) in the Kyverno GitHub repository and reference it.
 
+**Symptom**: I'm using AKS and Kyverno is using too much memory or CPU
+
+**Solution**: On AKS the kyverno webhooks will be mutated by the [Admissions Enforcer](https://learn.microsoft.com/en-us/azure/aks/faq#can-admission-controller-webhooks-impact-kube-system-and-internal-aks-namespaces) that can lead to an endless update loop. To prevent that behaviour, you can set the annotation `"admissions.enforcer/disabled": true` to all kyverno webhooks. When installing via Helm, you can change the annotations with `config.webhookAnnotations`.
+
 ## Kyverno is slow to respond
 
 **Symptom**: Kyverno's operation seems slow in either mutating resources or validating them, causing additional time to create resources in the Kubernetes cluster.


### PR DESCRIPTION
## Related issue

Closes #788 

## Proposed Changes
Based on our findings in https://github.com/kyverno/kyverno/issues/6539 we want to add a new Troubleshooting section about aks managed clusters and the webhook endless loop.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
