### PR TITLE
fix: typo in writing policies / variables

### DIFF
--- a/content/en/docs/Writing policies/variables.md
+++ b/content/en/docs/Writing policies/variables.md
@@ -385,7 +385,7 @@ And below allows for an inline variable with a nested object as well as a defaul
         # the default value may also be another variable, for example something from the AdmissionReview
         default: '{}'
         # jmespath expression that can be used to modify the `value` before it is assigned to the variable
-        jmespath: 'to_string(@)'
+        jmesPath: 'to_string(@)'
 ```
 
 Variables can reference other variables as well as shown below. Note that context variables are ordered; a variable consumed by another variable must be defined higher in the list of context variables.


### PR DESCRIPTION
## Related issue #

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

Non opened.

## Proposed Changes

Fixing typo. 
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [ ] I have inspected the website preview for accuracy.
- [ ] I have signed off my issue.
