### PR TITLE
Clarify default PolicyException namespace behavior

### DIFF
--- a/content/en/docs/Installation/_index.md
+++ b/content/en/docs/Installation/_index.md
@@ -415,7 +415,7 @@ The following flags can also be used to control the advanced behavior of Kyverno
 9.  `dumpPayload`: toggles debug mode. When debug mode is enabled, the full AdmissionReview payload is logged. Additionally, resources of kind Secret are redacted. Default is `false`. Should only be used in policy development or troubleshooting scenarios, not left perpetually enabled.
 10. `enableTracing`: set to enable exposing traces. Default is `false`.
 11. `enablePolicyException`: set to `true` to enable the [PolicyException capability](/docs/writing-policies/exceptions/). Default is `false`.
-12. `exceptionNamespace`: set to the name of a Namespace where [PolicyExceptions](/docs/writing-policies/exceptions/) will only be permitted. PolicyExceptions created in any other Namespace will throw a warning. Implies the `enablePolicyException` flag is set to `true`.
+12. `exceptionNamespace`: set to the name of a Namespace where [PolicyExceptions](/docs/writing-policies/exceptions/) will only be permitted. PolicyExceptions created in any other Namespace will throw a warning. If not set, PolicyExceptions from all namespaces will be considered. Implies the `enablePolicyException` flag is set to `true`.
 13. `forceFailurePolicyIgnore`: set to force Failure Policy to `Ignore`. Default is `false`.
 14. `genWorkers`: the number of workers for processing generate policies concurrently. Default is `10`.
 15. `imagePullSecrets`: specifies secret resource names for image registry access credentials. Only a single value accepted currently due to an upstream bug.


### PR DESCRIPTION
## Related issue #

Coming from [a Slack question](https://kubernetes.slack.com/archives/CLGR9BJU9/p1679589356578679)
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

Adds a clarification of the default behavior if the `--exceptionNamespace` flag is unset.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
