### PR TITLE
Homepage Hyperlinks Fixed

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -59,9 +59,9 @@ The Kyverno CLI can be used to test policies and validate resources as part of a
 ### Interested in learning and contributing?
 
 <p class="mt-5 mx-auto">
-	Sign up on our <a href="https://groups.google.com/g/kyverno">mailing list</a> 
-	or the <a href="https://slack.k8s.io/#kyverno">Kyverno channel on Kubernetes Slack</a> for discussions, and join 
-	our next community meeting. Check out the <a href="/community/">community page</a> for more details. 
+	Sign up on our <a href="https://groups.google.com/g/kyverno" target="_blank">mailing list</a> 
+	or the <a href="https://slack.k8s.io/#kyverno" target="_blank">Kyverno channel on Kubernetes Slack</a> for discussions, and join 
+	our next community meeting. Check out the <a href="/community/" target="_blank">community page</a> for more details. 
 </p>
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/kyverno/kyverno)](https://goreportcard.com/report/github.com/kyverno/kyverno) 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module kyverno
 
 go 1.18
 
-require (
-	github.com/google/docsy v0.6.0 // indirect
-	github.com/google/docsy/dependencies v0.6.0 // indirect
-)
+require github.com/google/docsy v0.6.0 // indirect


### PR DESCRIPTION
## Related issue #

Solves issue #791

## Proposed Changes

As the hyperlinks on the homepage were opening in the page as of the website, this PR makes them redirect to their separate independent pages.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
