### PR TITLE
Homepage Hyperlinks Fixed

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -59,9 +59,9 @@ The Kyverno CLI can be used to test policies and validate resources as part of a
 ### Interested in learning and contributing?
 
 <p class="mt-5 mx-auto">
-	Sign up on our <a href="https://groups.google.com/g/kyverno">mailing list</a> 
-	or the <a href="https://slack.k8s.io/#kyverno">Kyverno channel on Kubernetes Slack</a> for discussions, and join 
-	our next community meeting. Check out the <a href="/community/">community page</a> for more details. 
+	Sign up on our <a href="https://groups.google.com/g/kyverno" target="_blank">mailing list</a> 
+	or the <a href="https://slack.k8s.io/#kyverno" target="_blank">Kyverno channel on Kubernetes Slack</a> for discussions, and join 
+	our next community meeting. Check out the <a href="/community/" target="_blank">community page</a> for more details. 
 </p>
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/kyverno/kyverno)](https://goreportcard.com/report/github.com/kyverno/kyverno) 


### PR DESCRIPTION
## Related issue #

Closes #791 

## Proposed Changes
As the hyperlinks on the homepage were opening in the same page as of the website, this PR makes them redirect to their independent pages.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
