### PR TITLE
fix: policy rule info total metric values

### DIFF
--- a/content/en/docs/Monitoring/policy-rule-info-total.md
+++ b/content/en/docs/Monitoring/policy-rule-info-total.md
@@ -10,8 +10,7 @@ weight: 10
 
 **Metric Value**
 
-* 0 - if the rule is not anymore present in the cluster (although it was created in the past).
-* 1 - if the rule is currently actively present in the cluster.
+* 1 - for rules currently actively present in the cluster.
 
 ## Use cases
 


### PR DESCRIPTION
## Related issue #

This PR fixes policy rule info total metric values (we don't export `0` values anymore).
