### PR TITLE
fix: enforce/audit are deprecated

### DIFF
--- a/content/en/policies/psa/deny-privileged-profile/deny-privileged-profile.md
+++ b/content/en/policies/psa/deny-privileged-profile/deny-privileged-profile.md
@@ -34,7 +34,7 @@ metadata:
       the cluster-admin ClusterRole may create Namespaces which assign the label
       `pod-security.kubernetes.io/enforce=privileged`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
   - name: check-privileged


### PR DESCRIPTION
## Related issue ##

Getting error when applying the policy
```
Warning: Validation failure actions enforce/audit are deprecated, use Enforce/Audit instead.
```

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->
Changing the `validationFailureAction: Audit`, instead of audit
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [] I have inspected the website preview for accuracy.
- [] I have signed off my issue.
