### PR TITLE
fix: update broken link to background scans page

### DIFF
--- a/content/en/docs/Writing policies/policy-settings.md
+++ b/content/en/docs/Writing policies/policy-settings.md
@@ -9,7 +9,7 @@ A [policy](/docs/kyverno-policies/) contains one or more rules, and the followin
 
 * **applyRules**: states how many of the rules in the parent policy should be applied to a matching resource. Values are `One` and `All` (default). If set to `One`, the first matching rule to be applied will stop further rules from being evaluated.
 
-* **background**: controls scanning of existing resources to find potential violations and generating Policy Reports. See the documentation [here](/docs/policy-reports/background/). Default to "true".
+* **background**: controls scanning of existing resources to find potential violations and generating Policy Reports. See the documentation [here](/docs/writing-policies/background/). Default to "true".
 
 * **failurePolicy**: defines the API server behavior if the webhook fails to respond. Allowed values are "Ignore" or "Fail". Defaults to "Fail". Additionally, if set to "Ignore" will allow failing calls to image registries to be ignored. This allows for rule types like verifyImages or others which use image data to not block if the registry is temporarily down, useful in situations where images already exist on the nodes.
 

--- a/content/en/docs/Writing policies/policy-settings.md
+++ b/content/en/docs/Writing policies/policy-settings.md
@@ -9,7 +9,7 @@ A [policy](/docs/kyverno-policies/) contains one or more rules, and the followin
 
 * **applyRules**: states how many of the rules in the parent policy should be applied to a matching resource. Values are `One` and `All` (default). If set to `One`, the first matching rule to be applied will stop further rules from being evaluated.
 
-* **background**: controls scanning of existing resources to find potential violations and generating Policy Reports. See the documentation [here](/docs/writing-policies/background/). Default to "true".
+* **background**: controls scanning of existing resources to find potential violations and generating Policy Reports. See the documentation [here](/docs/policy-reports/background/). Default to "true".
 
 * **failurePolicy**: defines the API server behavior if the webhook fails to respond. Allowed values are "Ignore" or "Fail". Defaults to "Fail". Additionally, if set to "Ignore" will allow failing calls to image registries to be ignored. This allows for rule types like verifyImages or others which use image data to not block if the registry is temporarily down, useful in situations where images already exist on the nodes.
 


### PR DESCRIPTION
## Related issue #

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

Fixes #896. 

## Proposed Changes

This PR contains a fix to a broken hyperlink found in the docs. The [relevant page](https://kyverno.io/docs/writing-policies/policy-settings/) points to [`docs/writing-policies/background/`](https://kyverno.io/docs/writing-policies/background/) which was moved to [`docs/policy-reports/background/`](https://kyverno.io/docs/policy-reports/background/).  See #896 issue.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
