### PR TITLE
fix: webhookTimeout flag description not clear enough

### DIFF
--- a/content/en/docs/Installation/customization.md
+++ b/content/en/docs/Installation/customization.md
@@ -314,7 +314,7 @@ The following flags can be used to control the advanced behavior of the various 
 55. `v` (ABCR): sets the verbosity level of Kyverno log output. Takes an integer from 1 to 6 with 6 being the most verbose. Level 4 shows variable substitution messages. Default is `2`.
 56. `vmodule` (ABCR): comma-separated list of pattern=N settings for file-filtered logging.
 57. `webhookRegistrationTimeout` (A): specifies the length of time Kyverno will try to register webhooks with the API server. Defaults to `120s`.
-58. `webhookTimeout` (A): specifies the timeout for webhooks. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Defaults is `10s`.
+58. `webhookTimeout` (A): specifies the timeout for webhooks, in seconds. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be an integer number between 1 and 30 (seconds). Defaults is `10`.
 
 ### Policy Report access
 


### PR DESCRIPTION
## Related issue #

This PR fixes webhookTimeout flag description not clear enough.
