### PR TITLE
fix: allow dropping metrics, labels and configuring histogram bucket boundaries to avoid high cardinality

### DIFF
--- a/content/en/docs/Monitoring/_index.md
+++ b/content/en/docs/Monitoring/_index.md
@@ -119,27 +119,41 @@ reportsController:
 
 ## Configuring the metrics
 
-While installing Kyverno via Helm, you also have the ability to configure which metrics to expose.
+While installing Kyverno via Helm, you also have the ability to configure which metrics to expose, this configuration will be stored in the `kyverno-metrics` ConfigMap.
 
-You can configure which Namespaces you want to `include` and/or `exclude` for metric exportation when configuring your Helm chart. This configuration is useful in situations where you might want to exclude the exposure of Kyverno metrics for certain Namespaces like test or experimental Namespaces. Likewise, you can include certain Namespaces if you want to monitor Kyverno-related activity for only a set of certain critical Namespaces. Exporting the right set of Namespaces (as opposed to exposing all Namespaces) can end up substantially reducing the memory footprint of Kyverno's metrics exporter.
+You can configure which Namespaces you want to `include` and/or `exclude` for metric exportation when configuring your Helm chart. This configuration is useful in situations where you might want to exclude the exposure of Kyverno metrics for certain Namespaces like test or experimental Namespaces. Likewise, you can include certain Namespaces if you want to monitor Kyverno-related activity for only a set of certain critical Namespaces. Exporting the right set of Namespaces (as opposed to exposing all Namespaces) can end up substantially reducing the memory footprint of Kyverno's metrics exporter. Moreover, you can also configure the exposure of specific metrics, disabling them completely or dropping some label dimensions. For Histograms, you can change the default bucket boundaries or configure it for a specific metric as well.
 
-```sh
+```yaml
 ...
 metricsConfig:
-  namespaces: {
-    "include": [],
-    "exclude": []
-  }
-# 'namespaces.include': list of namespaces to capture metrics for. Default: all namespaces included.
-# 'namespaces.exclude': list of namespaces to NOT capture metrics for. Default: [], none of the namespaces excluded.
+  # 'namespaces.include': list of namespaces to capture metrics for. Default: all namespaces included.
+  # 'namespaces.exclude': list of namespaces to NOT capture metrics for. Default: [], none of the namespaces excluded.
+  # `exclude` takes precedence over `include` in cases when a Namespace is provided under both.
+  namespaces:
+    include: []
+    exclude: []
+
+  # Configures the bucket boundaries for all Histogram metrics, the value below is the default.
+  bucketBoundaries: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 20, 25, 30]
+
+  # Per Metric configuration, allows disabling metrics, dropping labels and change the bucket boundaries.
+  metricsExposure:
+    kyverno_policy_execution_duration_seconds:
+      disabledLabelDimensions: ["resource_kind", "resource_namespace", "resource_request_operation"]
+      bucketBoundaries: [0.005, 0.01, 0.025]
+    kyverno_admission_review_duration_seconds:
+      enabled: false
 ...
 ```
-
-`exclude` takes precedence over `include` in cases when a Namespace is provided under both.
 
 ## Disabling metrics
 
 Some metrics may generate an excess amount of data which may be undesirable in situations where this incurs additional cost. Some monitoring products and solutions have the ability to selectively disable which metrics are sent to collectors while leaving others enabled.
+
+### Kyverno configuration side
+As described [above](#configuring-the-metrics), Kyverno allows disabling metrics, dropping labels and changing the bucket boundaries by changing the `kyverno-metrics` ConfigMap, please refer to the example provided.
+
+### DataDog OpenMetrics side
 
 Disabling select metrics with [DataDog OpenMetrics](https://docs.datadoghq.com/integrations/openmetrics/) can be done by annotating the Kyverno Pod(s) as shown below.
 


### PR DESCRIPTION
## Related issue #

https://github.com/kyverno/kyverno/issues/8401
https://github.com/kyverno/kyverno/pull/8569

## Proposed Changes

This changes evolves the metrics related configuration done via the `kyverno-metrics` ConfigMap, exposing two new fields as following:
- `metricsExposure`: this is a map of a struct allowing each metric to be disabled, filtered labels or changed the bucket boundaries.
- `bucketBoundaries`: this configures the default bucket boundaries for all histograms.

It's worth mentioning this change does not change the default metrics configuration currently in use by Kyverno, meaning that all metrics, labels and bucket dimensions currently in use are preserved by default.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
