### PR TITLE
Move dot in Kyverno Policies documentation page

### DIFF
--- a/content/en/docs/Kyverno Policies/_index.md
+++ b/content/en/docs/Kyverno Policies/_index.md
@@ -11,7 +11,7 @@ A Kyverno policy is a collection of rules. Each rule consists of a [`match`](/do
 <br/>
 <br/>
 
-Policies can be defined as cluster-wide resources (using the kind `ClusterPolicy`) or namespaced resources (using the kind `Policy`.) As expected, namespaced policies will only apply to resources within the namespace in which they are defined while cluster-wide policies are applied to matching resources across all namespaces. Otherwise, there is no difference between the two types.
+Policies can be defined as cluster-wide resources (using the kind `ClusterPolicy`) or namespaced resources (using the kind `Policy`). As expected, namespaced policies will only apply to resources within the namespace in which they are defined while cluster-wide policies are applied to matching resources across all namespaces. Otherwise, there is no difference between the two types.
 
 Additional policy types include [Policy Exceptions](/docs/writing-policies/exceptions/) and [Cleanup Policies](/docs/writing-policies/cleanup/) which are separate resources and described further in the documentation.
 


### PR DESCRIPTION
## Related issue #
This is just a result of a probable diagnosis on my part. :)

## Proposed Changes
Just moving a dot to the correct side of the parentheses.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
