### PR TITLE
feat: add documentation for imageRegistryCredentials

### DIFF
--- a/content/en/docs/Writing policies/verify-images/_index.md
+++ b/content/en/docs/Writing policies/verify-images/_index.md
@@ -45,7 +45,7 @@ The `imageRegistryCredentials` attribute allows configuration of registry creden
 
 The `imageRegistryCredentials.helpers` is an array of credential helpers that can be used for this policy. Allowed values are `default`,`google`,`azure`,`amazon`,`github`.
 
-The `imageRegistryCredentials.secret` specifies a list of secrets that are provided for credentials. Secrets must be in the Kyverno namespace
+The `imageRegistryCredentials.secret` specifies a list of secrets that are provided for credentials. Secrets must be in the Kyverno namespace.
 
 For additional details please reference a section below for the solution used to sign the images and attestations:
 

--- a/content/en/docs/Writing policies/verify-images/_index.md
+++ b/content/en/docs/Writing policies/verify-images/_index.md
@@ -21,6 +21,7 @@ Each rule contains the following common configuration attributes:
   * `mutateDigest`: converts tags to digests for matching images
   * `verifyDigest`: enforces that digests are used for matching images
   * `repository`: use a different repository for fetching signatures
+  * `imageRegistryCredentials`: use specific registry credentials for this policy.
 
 A verifyImages rule can contain a list of `attestors` or authorities used to check the attached image signature. The type of attestor supported will vary based on the tool used to sign the image. For example, Sigstore Cosign supports public keys, certificates, and keyless attestors.
 
@@ -39,6 +40,12 @@ The `imageVerify` rule can be combined with [auto-gen](/docs/writing-policies/au
 The `attestors` declaration specifies one or more ways of checking image signatures or attestations. The `attestors.count` specifies the required count of attestors in the `entries` list that must be verified. By default, and when not specified, all attestors are verified.
 
 The `attestors.count` specifies the required count of attestors in the entries list that must be verified. By default, and when not specified, all attestors are verified.
+
+The `imageRegistryCredentials` attribute allows configuration of registry credentials per policy. Kyverno falls back to global credentials if this is empty.
+
+The `imageRegistryCredentials.helpers` is an array of credential helpers that can be used for this policy. Allowed values are `default`,`google`,`azure`,`amazon`,`github`.
+
+The `imageRegistryCredentials.secret` specifies a list of secrets that are provided for credentials. Secrets must be in the Kyverno namespace
 
 For additional details please reference a section below for the solution used to sign the images and attestations:
 


### PR DESCRIPTION
## Related issue 
Closes: #985 

## Proposed Changes
Adds docs for `imageRegistryCredentials`  in `verifyImage` policies that can be used to configure registry credentials per policy.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
