### PR TITLE
fix: Update Grafana Dashboard JSON URL

### DIFF
--- a/content/en/docs/Monitoring/bonus-grafana-dashboard.md
+++ b/content/en/docs/Monitoring/bonus-grafana-dashboard.md
@@ -11,7 +11,7 @@ weight: 60
 * Download the dashboard's JSON and save it in `kyverno-dashboard.json`
 
 ```sh
-curl https://raw.githubusercontent.com/kyverno/grafana-dashboard/master/grafana/dashboard.json -o kyverno-dashboard.json
+curl https://raw.githubusercontent.com/kyverno/kyverno/main/charts/kyverno/charts/grafana/dashboard/dashboard.json -o kyverno-dashboard.json
 ```
 
 * Open your Grafana portal and go to the option of importing a dashboard.


### PR DESCRIPTION
## Related issue #

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

The current Grafana Dashboard JSON URL appears to point to an old repo, I found the equivalent in the new repo and updated the docs accordingly. This appears to be the only reference to this URL in the docs and I verified with `hugo server` and running the new command on my terminal.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [X] I have inspected the website preview for accuracy.
- [X] I have signed off my issue.
