### PR TITLE
fix: use conditional anchor instead of equality for restrict-scale

### DIFF
--- a/content/en/policies/other/restrict-scale/restrict-scale.md
+++ b/content/en/policies/other/restrict-scale/restrict-scale.md
@@ -46,8 +46,8 @@ spec:
     validate:
       message: The replica count for this Deployment may not exceed 8.
       pattern:
-        =(status):
-          =(selector): "*type=monitoring*"
+        (status):
+          (selector): "*type=monitoring*"
         spec:
           replicas: <9
   # This rule can be used for more advanced decision making, for example limiting scale based


### PR DESCRIPTION
## Related issue #

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

Use Conditional Anchor instead of Equality because this is the intended behavior of the policy as stated in its description.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
