### PR TITLE
[1.13] docs: Add `imageIndex` field to `imageData`

### DIFF
--- a/content/en/docs/Writing policies/external-data-sources.md
+++ b/content/en/docs/Writing policies/external-data-sources.md
@@ -611,6 +611,7 @@ the output `imageData` variable will have a structure which looks like the follo
     "registry":      "ghcr.io",
     "repository":    "kyverno/kyverno",
     "identifier":    "latest",
+    "imageIndex":    imageIndex,
     "manifest":      manifest,
     "configData":    config,
 }
@@ -630,7 +631,7 @@ The `imageData` variable represents a "normalized" view of an image after any re
 ```
 {{% /alert %}}
 
-The `manifest` and `config` keys contain the output from `crane manifest <image>` and `crane config <image>` respectively.
+The `imageIndex`, `manifest` and `config` keys contain the output from `crane manifest <image>` and `crane config <image>` respectively.
 
 For example, one could inspect the labels, entrypoint, volumes, history, layers, etc of a given image. Using the [crane](https://github.com/google/go-containerregistry/tree/main/cmd/crane) tool, show the config of the `ghcr.io/kyverno/kyverno:latest` image:
 


### PR DESCRIPTION
## Related issue #
Issue - kyverno/kyverno#8273
PR - kyverno/kyverno#9883

## Proposed Changes
Add `imageIndex` to `imageData` documentation.

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [X] I have inspected the website preview for accuracy.
- [X] I have signed off my issue.
