### PR TITLE
add instructions for accessing earlier docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Source for: https://kyverno.io
 
+## Accessing Earlier Documentation
+
+The Kyverno website follows the same support policy as Kyverno, an N-2 policy. Documentation will be made available for the current release and the two previous minor releases. While this extends to the version list on the website, users may still access earlier versions of the documentation by navigating to a specific version by URL.
+
+Documentation for each version is published at a URL like `https://release-X-Y-0.kyverno.io/` where `X` is the major version and `Y` is the minor version. To access the documentation for version 1.9.0, navigate to the URL [https://release-1-9-0.kyverno.io/](https://release-1-9-0.kyverno.io/).
+
 ## Contributors
 
 <a href="https://github.com/kyverno/website/graphs/contributors">
@@ -30,6 +36,7 @@ git clone https://github.com/{YOUR-GITHUB-ID}/website kyverno-website/
 cd kyverno-website
 hugo server
 ```
+
 **Note For Windows Users:** When running the `hugo server` command, make sure to execute it with administrator privileges in your terminal. This is necessary to ensure proper access and functionality during the server execution.
 
 By default, Hugo runs the website at: http://localhost:1313 and will re-build the site on changes.


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## Related issue #

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

Adds a section to README instructing users on how to access earlier versions of the Kyverno documentation which does not appear via the version drop-down list on the site itself.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
