### PR TITLE
feat: add apiserver storage object metric to reports-server blog

### DIFF
--- a/content/en/blog/general/introducing-reports-server/index.md
+++ b/content/en/blog/general/introducing-reports-server/index.md
@@ -37,7 +37,7 @@ Reports server stores policy reports and ephemeral reports outside etcd thus red
 
 ### Without Reports Server
 
-Below is the count of reports in etcd without reports server. When reports server is not installed, `apiserver_storage_objects` reports that there are 10000+ policy reports in etcd:
+Below is the count of reports in etcd without the reports server. When the reports server is not installed, `apiserver_storage_objects` reports that there are 10000+ policy reports in etcd:
 
 ```bash
 $ kubectl get --raw=/metrics | grep apiserver_storage_objects | awk '$2>100' |sort -g -k 2

--- a/content/en/blog/general/introducing-reports-server/index.md
+++ b/content/en/blog/general/introducing-reports-server/index.md
@@ -37,7 +37,8 @@ Reports server stores policy reports and ephemeral reports outside etcd thus red
 
 ### Without Reports Server
 
-Below is the count of reports in etcd without reports server:
+Below is the count of reports in etcd without reports server. When reports server is not installed, `apiserver_storage_objects` reports that there are 10000+ policy reports in etcd:
+
 ```bash
 $ kubectl get --raw=/metrics | grep apiserver_storage_objects | awk '$2>100' |sort -g -k 2
 # HELP apiserver_storage_objects [STABLE] Number of stored objects at the time of last check split by kind.
@@ -67,7 +68,8 @@ Total size of etcd, including all resources in the cluster with respect to amoun
 
 ### With Reports Server
 
-Here is the count of objects in etcd without reports server, when 10000+ policy reports are present in the cluster:
+Here is the count of objects in etcd without reports server, when 10000+ policy reports are present in the cluster. When reports server is installed, `apiserver_storage_objects` does not report find any policy reports in etcd and is therefore not reported. When we query for policy reports using kubectl, we see that there are 10000+ policy reports in the cluster:
+
 ```bash
 $ kubectl get --raw=/metrics | grep apiserver_storage_objects | awk '$2>100' |sort -g -k 2
 # HELP apiserver_storage_objects [STABLE] Number of stored objects at the time of last check split by kind.

--- a/content/en/blog/general/introducing-reports-server/index.md
+++ b/content/en/blog/general/introducing-reports-server/index.md
@@ -68,7 +68,7 @@ Total size of etcd, including all resources in the cluster with respect to amoun
 
 ### With Reports Server
 
-Here is the count of objects in etcd without reports server, when 10000+ policy reports are present in the cluster. When reports server is installed, `apiserver_storage_objects` does not report find any policy reports in etcd and is therefore not reported. When we query for policy reports using kubectl, we see that there are 10000+ policy reports in the cluster:
+Here is the count of objects in etcd with the reports server, when 10000+ policy reports are present in the cluster. When the reports server is installed, `apiserver_storage_objects` does not find any policy reports in etcd and is therefore not reported. When we query for policy reports using kubectl, we see that there are 10000+ policy reports in the cluster:
 
 ```bash
 $ kubectl get --raw=/metrics | grep apiserver_storage_objects | awk '$2>100' |sort -g -k 2

--- a/content/en/blog/general/introducing-reports-server/index.md
+++ b/content/en/blog/general/introducing-reports-server/index.md
@@ -37,6 +37,24 @@ Reports server stores policy reports and ephemeral reports outside etcd thus red
 
 ### Without Reports Server
 
+Below is the count of reports in etcd without reports server:
+```bash
+$ kubectl get --raw=/metrics | grep apiserver_storage_objects | awk '$2>100' |sort -g -k 2
+# HELP apiserver_storage_objects [STABLE] Number of stored objects at the time of last check split by kind.
+# TYPE apiserver_storage_objects gauge
+apiserver_storage_objects{resource="nodes"} 108
+apiserver_storage_objects{resource="leases.coordination.k8s.io"} 123
+apiserver_storage_objects{resource="deployments.apps"} 857
+apiserver_storage_objects{resource="replicasets.apps"} 859
+apiserver_storage_objects{resource="pods"} 8540
+apiserver_storage_objects{resource="policyreports.wgpolicyk8s.io"} 10268
+
+$ kubectl get polr -A | wc -l
+10269
+```
+`apiserver_storage_objects` metrics show that there are 10000+ policy reports stored in etcd along with other resources.
+
+Total size of etcd, including all resources in the cluster with respect to amount of policy reports:
 | Number of Policy Reports | Total etcd Size |
 | --------------- | --------------- |
 | 1270            | 134 MB          |
@@ -49,6 +67,23 @@ Reports server stores policy reports and ephemeral reports outside etcd thus red
 
 ### With Reports Server
 
+Here is the count of objects in etcd without reports server, when 10000+ policy reports are present in the cluster:
+```bash
+$ kubectl get --raw=/metrics | grep apiserver_storage_objects | awk '$2>100' |sort -g -k 2
+# HELP apiserver_storage_objects [STABLE] Number of stored objects at the time of last check split by kind.
+# TYPE apiserver_storage_objects gauge
+apiserver_storage_objects{resource="nodes"} 108
+apiserver_storage_objects{resource="leases.coordination.k8s.io"} 123
+apiserver_storage_objects{resource="deployments.apps"} 855
+apiserver_storage_objects{resource="replicasets.apps"} 857
+apiserver_storage_objects{resource="pods"} 8540
+
+$ kubectl get polr -A | wc -l
+10249
+```
+`apiserver_storage_objects` metric does not find policy reports stored in etcd.
+
+Total size of etcd, including all resources in the cluster with respect to amount of policy reports:
 | Number of Policy Reports | Total etcd Size |
 | --------------- | --------------- |
 | 1204            | 71 MB           |


### PR DESCRIPTION
## Related issue #
N/A
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

This pr adds `apiserver_storage_objects` metric to reports-server blog which shows the number of resources stored in etcd.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [] I have inspected the website preview for accuracy.
- [] I have signed off my issue.
