### PR TITLE
Helm values.yaml file example doesn't work for high availability

### DIFF
--- a/content/en/docs/installation/methods.md
+++ b/content/en/docs/installation/methods.md
@@ -45,10 +45,15 @@ Since Kyverno is comprised of different controllers where each is contained in s
 The Helm chart offers parameters to configure multiple replicas for each controller. For example, a highly-available, complete deployment of Kyverno would consist of the following values.
 
 ```yaml
-admissionController.replicas: 3
-backgroundController.replicas: 2
-cleanupController.replicas: 2
-reportsController.replicas: 2
+admissionController:
+  replicas: 3
+backgroundController:
+  replicas: 2
+cleanupController:
+  replicas: 2
+reportsController:
+  replicas: 2
+
 ```
 
 For all of the available values and their defaults, please see the Helm chart [README](https://github.com/kyverno/kyverno/tree/release-1.10/charts/kyverno). You should carefully inspect all available chart values and their defaults to determine what overrides, if any, are necessary to meet the particular needs of your production environment.


### PR DESCRIPTION
## Proposed Changes
The current example doesn't render properly using helm `version.BuildInfo{Version:"v3.14.3", GitCommit:"f03cc04caaa8f6d7c3e67cf918929150cf6f3f12", GitTreeState:"clean", GoVersion:"go1.22.1"}
`

## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [] I have signed off my issue.
