### PR TITLE
Add missing CPU specification to the Kubernetes resource policy example in autogen.md

### DIFF
--- a/content/en/docs/writing-policies/autogen.md
+++ b/content/en/docs/writing-policies/autogen.md
@@ -164,6 +164,7 @@ spec:
                     cpu: "?*"
                   limits:
                     memory: "?*"
+                    cpu: "?*"
 ```
 
 The result will have the same effect as the first snippet which uses an `exclude` block and have the benefit of auto-generation coverage.


### PR DESCRIPTION
Signed-off-by: nikhilmaheshwari24 nikhil.m2498@gmail.com

## Related issue #
NA
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

This pull request adds a missing CPU specification to the Kubernetes resource policy example in the autogen.md file. The change ensures consistency and completeness in the documentation, helping users understand the proper structure and usage of resource policies with CPU limits.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
