### PR TITLE
Add Scarf documentation pixel to site footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -23,6 +23,7 @@
       </div>
     </div>
   </div>
+  <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=8be4de30-8c1a-446b-a3cc-9a02346ccb1d" />
 </footer>
 {{ define "footer-links-block" }}
 <ul class="list-inline mb-0">


### PR DESCRIPTION
## Related issue #

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

@JimBugwadia

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

This PR updates the Kyverno documentation website by adding a pixel to the footer of the website. The pixel does not impact site speed times, does not contain cookies or JavaScript, and is purely an HTML image that collects basic de-identified download and adoption metrics.

This change was suggested in direct discussions with Kyverno folks. 

Scarf purges PII, complies with the GDPR, and is approved for usage by the CNCF. Kyverno users can easily opt out of analytics in various ways documented [here](https://docs.scarf.sh/gateway/#do-not-track). 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [] I have signed off my issue.
