### PR TITLE
bugfix: `Render` to cleanup all the directories

### DIFF
--- a/render/render.go
+++ b/render/render.go
@@ -136,6 +136,11 @@ func render(git *gitInfo, outdir string) error {
 		if err != nil {
 			return fmt.Errorf("failed to clean directory %s: %v", outdir, err)
 		}
+
+		err = removeEmptyDirs(outdir)
+		if err != nil {
+			return fmt.Errorf("failed to clean directory %s: %v", outdir, err)
+		}
 	}
 
 	for _, yamlFilePath := range yamls {
@@ -203,6 +208,58 @@ func render(git *gitInfo, outdir string) error {
 	}
 
 	return nil
+}
+
+// removeEmptyDirs collects directories and deletes empty ones from deepest to shallowest
+func removeEmptyDirs(dir string) error {
+	var dirs []string
+
+	// First, traverse the directory tree to collect directories
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			dirs = append(dirs, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Sort directories by depth (deepest directories first)
+	sort.Slice(dirs, func(i, j int) bool {
+		return len(dirs[i]) > len(dirs[j])
+	})
+
+	// Attempt to delete directories, starting from the deepest
+	for _, path := range dirs {
+		empty, err := isEmptyDir(path)
+		if err != nil {
+			return err
+		}
+		if empty {
+			if Verbose {
+				log.Printf("Removing empty directory: %s\n", path)
+			}
+			err := os.Remove(path)
+			if err != nil {
+				fmt.Printf("Failed to remove directory %s: %v", path, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// isEmptyDir checks if a directory is empty
+func isEmptyDir(dirPath string) (bool, error) {
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		return false, err
+	}
+	return len(entries) == 0, nil
 }
 
 // deleteMarkdownFiles deletes all .md files except "_index.md"


### PR DESCRIPTION
## Related issue #
Fixes #929 

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

The bug was due to the code not recursively searching the directory for `.md` files. We have modified the code to search directories and sub-directories. 

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
