### PR TITLE
fix: update log4j security link

### DIFF
--- a/content/en/policies/other/mitigate-log4shell/mitigate-log4shell.md
+++ b/content/en/policies/other/mitigate-log4shell/mitigate-log4shell.md
@@ -5,7 +5,7 @@ version: 1.6.0
 subject: Pod
 policyType: "mutate"
 description: >
-    In response to CVE-2021-44228 referred to as Log4Shell, a RCE vulnerability in the Log4j library, a partial yet incomplete workaround for versions 2.10 to 2.14.1 of the library is to set the environment variable LOG4J_FORMAT_MSG_NO_LOOKUPS to "true". While this does provide some benefit by limiting exposure, there are still code paths which can exploit this vulnerability. It is highly recommended to upgrade log4j as soon as possible. See https://logging.apache.org/log4j/2.x/security.html for more details. This policy will mutate all initContainers and containers in an incoming Pod to add this environment variable automatically.
+    In response to CVE-2021-44228 referred to as Log4Shell, a RCE vulnerability in the Log4j library, a partial yet incomplete workaround for versions 2.10 to 2.14.1 of the library is to set the environment variable LOG4J_FORMAT_MSG_NO_LOOKUPS to "true". While this does provide some benefit by limiting exposure, there are still code paths which can exploit this vulnerability. It is highly recommended to upgrade log4j as soon as possible. See https://logging.apache.org/security.html for more details. This policy will mutate all initContainers and containers in an incoming Pod to add this environment variable automatically.
 ---
 
 ## Policy Definition
@@ -29,7 +29,7 @@ metadata:
       variable LOG4J_FORMAT_MSG_NO_LOOKUPS to "true". While this does provide some
       benefit by limiting exposure, there are still code paths which can exploit
       this vulnerability. It is highly recommended to upgrade log4j as soon as possible.
-      See https://logging.apache.org/log4j/2.x/security.html for more details.
+      See https://logging.apache.org/security.html for more details.
       This policy will mutate all initContainers and containers in an
       incoming Pod to add this environment variable automatically.
 spec:


### PR DESCRIPTION
## Related issue #
#1340 

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes
Security link for log4j is updated. 
Old: https://logging.apache.org/log4j/2.x/security.html
New: https://logging.apache.org/security.html
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
