### PR TITLE
update certificates renewal time before expiration

### DIFF
--- a/content/en/docs/installation/customization.md
+++ b/content/en/docs/installation/customization.md
@@ -61,13 +61,13 @@ At a minimum, managed certificates are checked for validity every 12 hours. Addi
 
 The renewal process runs as follows:
 1. Remove expired certificates contained in the secret
-1. Check if remaining certificates will become invalid in less than 60 hours
+1. Check if remaining certificates will become invalid in less than 15 days
 1. If needed, generate a new certificate with the validity documented above
 1. The new certificates is added to the underlying secret along with current certificatess that are still valid
 1. Reconfigure webhooks with the new certificates bundle
 1. Update the Kyverno server to use the new certificate
 
-Basically, certificates will be renewed approximately 60 hours before expiry.
+Basically, certificates will be renewed approximately 15 days before expiry.
 
 #### Custom certificates
 


### PR DESCRIPTION
## Related issue #

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

fixing inconsistent documentation on certificates renewal time before expiration.

https://github.com/kyverno/kyverno/blob/8fec1ad76431a084cc62fedefaaa24a4a96a8953/cmd/kyverno/main.go#L298

```go
flagset.DurationVar(&renewBefore, "renewBefore", 15*24*time.Hour, "The certificate renewal time before expiration")
```

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [] I have signed off my issue.
