### PR TITLE
doc: update hugo installation for github codespaces users

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ hugo server
 
 By default, Hugo runs the website at: http://localhost:1313 and will re-build the site on changes.
 
-**Note for Github Codespaces User:** You might be required to install the hugo extended version. To do so download the extended version from [hugo release](https://github.com/gohugoio/hugo/releases) based on your operation system (mostly it is Ubuntu for Codespaces). Use the below commands to install and then move the hugo directory to `usr/local/hugo/bin/hugo`
+**Note for Github Codespaces User:** You will be required to install the hugo extended version. To do so download the extended version from [hugo release](https://github.com/gohugoio/hugo/releases) based on your operation system (mostly it is Ubuntu for Codespaces). Use the below commands to install and then move the hugo directory to `usr/local/hugo/bin/hugo`
 ```
 wget https://github.com/gohugoio/hugo/releases/download/v0.135.0/hugo_extended_0.135.0_linux-amd64.deb
 sudo dpkg -i hugo_extended_0.135.0_linux-amd64.deb

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ hugo server
 
 By default, Hugo runs the website at: http://localhost:1313 and will re-build the site on changes.
 
+**Note for Github Codespaces User:** You might be required to install the hugo extended version. To do so download the extended version from [hugo release](https://github.com/gohugoio/hugo/releases) based on your operation system (mostly it is Ubuntu for Codespaces). Use the below commands to install and then move the hugo directory to `usr/local/hugo/bin/hugo`
+```
+wget https://github.com/gohugoio/hugo/releases/download/v0.135.0/hugo_extended_0.135.0_linux-amd64.deb
+sudo dpkg -i hugo_extended_0.135.0_linux-amd64.deb
+rm hugo_extended_0.135.0_linux-amd64.deb
+sudo mv /usr/local/bin/hugo /usr/local/hugo/bin/hugo
+```
+Finally, Check the hugo version by running: `hugo version`
+
 ## Update Docsy theme
 
 The project uses [Hugo Modules](https://gohugo.io/hugo-modules/) to manage the theme:


### PR DESCRIPTION
## Related issue #

When you first setup a codespace in github to run the website it is defaulted to the hugo version that comes with codespaces. But website requires hugo extended version to be installed.

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

Documentation added to manually install hugo extended version in the github codespaces.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
