### PR TITLE
docs: add warning for the mutateExistingOnPolicyUpdate deprecated field

### DIFF
--- a/content/en/docs/writing-policies/mutate.md
+++ b/content/en/docs/writing-policies/mutate.md
@@ -470,7 +470,6 @@ kind: ClusterPolicy
 metadata:
   name: mutate-existing-secret
 spec:
-  mutateExistingOnPolicyUpdate: true
   rules:
     - name: mutate-secret-on-configmap-event
       match:
@@ -483,6 +482,7 @@ spec:
               namespaces:
                 - staging
       mutate:
+        mutateExistingOnPolicyUpdate: true
         # ...
         targets:
           - apiVersion: v1
@@ -508,7 +508,6 @@ kind: ClusterPolicy
 metadata:
   name: refresh-env-var-in-pods
 spec:
-  mutateExistingOnPolicyUpdate: false
   rules:
   - name: refresh-from-secret-env
     match:
@@ -522,6 +521,7 @@ spec:
           operations:
           - UPDATE
     mutate:
+      mutateExistingOnPolicyUpdate: false
       targets:
         - apiVersion: apps/v1
           kind: Deployment
@@ -622,7 +622,6 @@ kind: ClusterPolicy
 metadata:
   name: sync-cms
 spec:
-  mutateExistingOnPolicyUpdate: false
   rules:
   - name: concat-cm
     match:
@@ -635,6 +634,7 @@ spec:
           namespaces:
           - foo
     mutate:
+      mutateExistingOnPolicyUpdate: false
       targets:
         - apiVersion: v1
           kind: ConfigMap
@@ -660,7 +660,6 @@ kind: ClusterPolicy
 metadata:
   name: sync-cms
 spec:
-  mutateExistingOnPolicyUpdate: false
   rules:
   - name: concat-cm
     match:
@@ -673,6 +672,7 @@ spec:
           namespaces:
           - foo
     mutate:
+      mutateExistingOnPolicyUpdate: false
       targets:
         - apiVersion: v1
           kind: ConfigMap
@@ -918,7 +918,6 @@ kind: ClusterPolicy
 metadata:
   name: demo-cluster-policy
 spec:
-  mutateExistingOnPolicyUpdate: false
   rules:
   - name: demo-generate
     match:
@@ -951,6 +950,7 @@ spec:
               matchLabels:
                 custom/related-namespace: "?*"
     mutate:
+      mutateExistingOnPolicyUpdate: false
       targets:
         - apiVersion: v1
           kind: Namespace

--- a/content/en/docs/writing-policies/policy-settings.md
+++ b/content/en/docs/writing-policies/policy-settings.md
@@ -17,7 +17,7 @@ A [policy](../kyverno-policies) contains one or more rules, and the following co
 
 * **generateExisting**: applicable to generate rules only. Controls whether Kyverno should evaluate the policy the moment it is created.
 
-* **mutateExistingOnPolicyUpdate**: applicable to mutate rules which define targets. Controls whether Kyverno should evaluate the policy when it is updated.
+* **mutateExistingOnPolicyUpdate**: applicable to mutate rules which define targets. Controls whether Kyverno should evaluate the policy when it is updated. This field is deprecated as of 1.13. Scheduled to be removed in a future version. Use `mutateExistingOnPolicyUpdate` under the mutate rule instead.
 
 * **schemaValidation**: controls whether policy validation checks are applied. Defaults to "true". Kyverno will attempt to validate the schema of a policy and fail if it cannot determine it satisfies the OpenAPI schema definition for that resource. Can occur on either validate or mutate policies. Set to "false" to skip schema validation. This field is deprecated as of 1.11 and currently has no effect. Scheduled to be removed in a future version.
 

--- a/content/en/docs/writing-policies/variables.md
+++ b/content/en/docs/writing-policies/variables.md
@@ -504,9 +504,7 @@ kind: ClusterPolicy
 metadata:
   name: vault-auth-backend
 spec:
-  validationFailureAction: Audit
   background: true
-  mutateExistingOnPolicyUpdate: true
   rules:
   - name: vault-injector-config-blue-to-green-auth-backend
     context:
@@ -523,6 +521,7 @@ spec:
           namespaces:
           - corp-tech-ap-team-ping-ep
     mutate:
+      mutateExistingOnPolicyUpdate: true
       patchStrategicMerge:
         data:
           config: '{{- hcl }}'


### PR DESCRIPTION
## Related issue #
Related to https://github.com/kyverno/website/issues/1335

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
