### PR TITLE
docs: add warning for the generateExisting deprecated field

### DIFF
--- a/content/en/docs/writing-policies/generate.md
+++ b/content/en/docs/writing-policies/generate.md
@@ -127,10 +127,6 @@ spec:
 
 For other examples of generate rules, see the [policy library](/policies/?policytypes=generate).
 
-{{% alert title="Note" color="info" %}}
-The field `spec.generateExisting` is no longer required for "classic" generate rules, is deprecated, and will be removed in an upcoming version.
-{{% /alert %}}
-
 ## Clone Source
 
 When a generate policy should take the source from a resource which already exists in the cluster, a `clone` object is used instead of a `data` object. When triggered, the generate policy will clone from the resource name and location defined in the rule to create the new resource. Use of the `clone` object implies no modification during the path from source to destination and Kyverno is not able to modify its contents (aside from metadata used for processing and tracking).
@@ -506,7 +502,7 @@ spec:
 
 Use of a `generate` rule is common when creating net new resources from the point after which the policy was created. For example, a Kyverno `generate` policy is created so that all future Namespaces can receive a standard set of Kubernetes resources. However, it is also possible to generate resources based on **existing** resources. This can be extremely useful especially for Namespaces when deploying Kyverno to an existing cluster where you wish policy to apply retroactively.
 
-Kyverno supports generation for existing resources. Generate existing policies are applied when the policy is created and in the background which creates target resources based on the match statement within the policy. They may also optionally be configured to apply upon updates to the policy itself. By defining the `spec.generateExisting` set to `true`, a generate rule will take effect for existing resources which have the same match characteristics.
+Kyverno supports generation for existing resources. Generate existing policies are applied when the policy is created and in the background which creates target resources based on the match statement within the policy. They may also optionally be configured to apply upon updates to the policy itself. By defining the `generate[*].generateExisting` set to `true`, a generate rule will take effect for existing resources which have the same match characteristics.
 
 Note that the benefits of using a "generate existing" rule is only the moment the policy is installed. Once the initial generation effects have been produced, the rule functions like a "standard" generate rule from that point forward. Generate existing rules are therefore primarily useful for one-time use cases when retroactive policy should be applied.
 
@@ -522,7 +518,6 @@ kind: ClusterPolicy
 metadata:
   name: generate-resources
 spec:
-  generateExisting: true
   rules:
   - name: generate-existing-networkpolicy
     match:
@@ -531,6 +526,7 @@ spec:
           kinds:
           - Namespace
     generate:
+      generateExisting: true
       kind: NetworkPolicy
       apiVersion: networking.k8s.io/v1
       name: default-deny
@@ -555,7 +551,6 @@ kind: ClusterPolicy
 metadata:
   name: create-default-pdb
 spec:
-  generateExisting: true
   rules:
   - name: create-default-pdb
     match:
@@ -568,6 +563,7 @@ spec:
         namespaces:
         - local-path-storage
     generate:
+      generateExisting: true
       apiVersion: policy/v1
       kind: PodDisruptionBudget
       name: "{{request.object.metadata.name}}-default-pdb"
@@ -582,7 +578,7 @@ spec:
 ```
 
 {{% alert title="Note" color="info" %}}
-The field `spec.generateExistingOnPolicyUpdate` has been replaced by `spec.generateExisting`. The former is no longer required, is deprecated, and will be removed in an upcoming version.
+The field `spec.generateExisting` has been replaced by `spec.rules[*].generate[*].generateExisting`. The former is no longer required, is deprecated, and will be removed in an upcoming version.
 {{% /alert %}}
 
 ## How It Works

--- a/content/en/docs/writing-policies/policy-settings.md
+++ b/content/en/docs/writing-policies/policy-settings.md
@@ -15,7 +15,7 @@ A [policy](../kyverno-policies) contains one or more rules, and the following co
 
 * **failurePolicy**: defines the API server behavior if the webhook fails to respond. Allowed values are "Ignore" or "Fail". Defaults to "Fail". Additionally, if set to "Ignore" will allow failing calls to image registries to be ignored. This allows for rule types like verifyImages or others which use image data to not block if the registry is temporarily down, useful in situations where images already exist on the nodes.
 
-* **generateExisting**: applicable to generate rules only. Controls whether Kyverno should evaluate the policy the moment it is created.
+* **generateExisting**: applicable to generate rules only. Controls whether Kyverno should evaluate the policy the moment it is created. This field is deprecated as of 1.13. Scheduled to be removed in a future version. Use `generateExisting` under the generate rule instead.
 
 * **mutateExistingOnPolicyUpdate**: applicable to mutate rules which define targets. Controls whether Kyverno should evaluate the policy when it is updated.
 

--- a/content/en/policies/argo/argo-cluster-generation-from-rancher-capi/argo-cluster-generation-from-rancher-capi.md
+++ b/content/en/policies/argo/argo-cluster-generation-from-rancher-capi/argo-cluster-generation-from-rancher-capi.md
@@ -33,7 +33,6 @@ metadata:
       "Cluster-API cluster auto-registration" and Rancher issue https://github.com/rancher/rancher/issues/38053
       "Fix type and labels Rancher v2 provisioner specifies when creating CAPI Cluster Secret".
 spec:
-  generateExisting: true
   rules:
   - name: source-rancher-non-local-cluster-and-capi-secret
     match:
@@ -99,6 +98,7 @@ spec:
           }
         jmesPath: 'to_string(@)'
     generate:
+      generateExisting: true
       synchronize: true
       apiVersion: v1
       kind: Secret

--- a/content/en/policies/kubeops/config-syncer-secret-generation-from-rancher-capi/config-syncer-secret-generation-from-rancher-capi.md
+++ b/content/en/policies/kubeops/config-syncer-secret-generation-from-rancher-capi/config-syncer-secret-generation-from-rancher-capi.md
@@ -30,7 +30,6 @@ metadata:
       required by the Kubeops Config Syncer for it to sync ConfigMaps/Secrets from
       the Rancher management cluster to downstream clusters.
 spec:
-  generateExisting: true
   rules:
   - name: source-rancher-non-local-cluster-and-capi-secret
     match:
@@ -101,6 +100,7 @@ spec:
         operator: NotEquals
         value: '{{ currentKubeconfigData }}'
     generate:
+      generateExisting: true
       synchronize: true
       apiVersion: v1
       kind: Secret

--- a/content/en/policies/other/generate-networkpolicy-existing/generate-networkpolicy-existing.md
+++ b/content/en/policies/other/generate-networkpolicy-existing/generate-networkpolicy-existing.md
@@ -31,7 +31,6 @@ metadata:
       is additional overhead. This policy creates a new NetworkPolicy for existing
       Namespaces which results in a default deny behavior and labels it with created-by=kyverno.
 spec:
-  generateExisting: true
   rules:
   - name: generate-existing-networkpolicy
     match:
@@ -40,6 +39,7 @@ spec:
           kinds:
           - Namespace
     generate:
+      generateExisting: true
       kind: NetworkPolicy
       apiVersion: networking.k8s.io/v1
       name: default-deny


### PR DESCRIPTION
## Related issue #
Related to https://github.com/kyverno/website/issues/1335
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
