### PR TITLE
fix: add warning to set permission in reports controller

### DIFF
--- a/content/en/docs/policy-reports/_index.md
+++ b/content/en/docs/policy-reports/_index.md
@@ -91,7 +91,7 @@ Reporting can be enabled or disabled for rule types by modifying the value of th
 {{% /alert %}}
 
 {{% alert title="Note" color="info" %}}
-Reporting for `generate` and `mutateExisting` rules require permission to fetch resource in kyverno reports controller.
+Creating reports for a resource require permission to `get`, `list` and `watch` the resource in kyverno reports controller.
 {{% /alert %}}
 
 ## Report result logic

--- a/content/en/docs/policy-reports/_index.md
+++ b/content/en/docs/policy-reports/_index.md
@@ -90,6 +90,10 @@ To configure Kyverno to generate reports for Kubernetes ValidatingAdmissionPolic
 Reporting can be enabled or disabled for rule types by modifying the value of the flag `--enableReporting=validate,mutate,mutateExisting,generate,imageVerify`.
 {{% /alert %}}
 
+{{% alert title="Note" color="info" %}}
+Reporting for `generate` and `mutateExisting` rules require permission to fetch resource in kyverno reports controller.
+{{% /alert %}}
+
 ## Report result logic
 
 Entries in a policy report contain a `result` field which can be either `pass`, `skip`, `warn`, `error`, or `fail`.

--- a/content/en/docs/policy-reports/_index.md
+++ b/content/en/docs/policy-reports/_index.md
@@ -91,7 +91,7 @@ Reporting can be enabled or disabled for rule types by modifying the value of th
 {{% /alert %}}
 
 {{% alert title="Note" color="info" %}}
-Creating reports for a resource require permission to `get`, `list` and `watch` the resource in kyverno reports controller.
+Creating reports for a resource require permissions to `get`, `list` and `watch` the resource in Kyverno reports controller.
 {{% /alert %}}
 
 ## Report result logic


### PR DESCRIPTION
## Related issue #

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [] I have inspected the website preview for accuracy.
- [] I have signed off my issue.
