### PR TITLE
Fix broken links and update ArgoCD header

### DIFF
--- a/content/en/blog/general/introducing-kyverno-envoy-plugin/index.md
+++ b/content/en/blog/general/introducing-kyverno-envoy-plugin/index.md
@@ -70,7 +70,7 @@ The `applicaition.yaml` manifest defines the following resource:
 
 - A ConfigMap `envoy-config` is used to pass an Envoy configuration with an External Authorization Filter to direct authorization checks to the Kyverno-Envoy-Plugin sidecar. 
 
-- The Deployment also includes an init container that install iptables rules to redirect all container traffic to the Envoy proxy sidecar container , more about init container can be found [here](https://github.com/kyverno/kyverno-envoy-plugin/tree/main/demo/standalone-envoy/envoy_iptables)
+- The Deployment also includes an init container that install iptables rules to redirect all container traffic to the Envoy proxy sidecar container , more about init container can be found [here](https://github.com/kyverno/kyverno-envoy-plugin/tree/main/docs/demo/standalone-envoy/envoy_iptables)
 
 ### Make Test application accessible in the cluster
 

--- a/content/en/docs/writing-policies/mutate.md
+++ b/content/en/docs/writing-policies/mutate.md
@@ -1214,7 +1214,7 @@ See the [platform notes](../installation/platform-notes.md#notes-for-argocd-user
 #### ArgoCD v2.10+
 
 
-For considerations when using Argo CD (v2.10+) along with Kyverno, ServerSideDiff is recommended as it resolves OutOfSync warnings by delegating the comparison process to Kubernetes. See the documentation [here](../installation/platform-notes.md#argocd).
+For considerations when using Argo CD (v2.10+) along with Kyverno, ServerSideDiff is recommended as it resolves OutOfSync warnings by delegating the comparison process to Kubernetes. See the documentation [here](../installation/platform-notes.md#notes-for-argocd-users).
 
 
 This [CNCF blog post](https://www.cncf.io/blog/2024/01/18/gitops-and-mutating-policies-the-tale-of-two-loops/) provides a complete example.


### PR DESCRIPTION
## Related issue

#1448 

## Proposed Changes

This PR addresses two issues in the documentation

- Fixes a broken link to the GitHub repository by updating it with the correct URL.
- Corrects the ArgoCD header name in the URL to ensure it accurately points to the right section.

Files Modified:

content/en/blog/general/introducing-kyverno-envoy-plugin/index.md
![image](https://github.com/user-attachments/assets/f0decf2f-8078-4a8a-873f-e86c3268ff93)

content/en/docs/writing-policies/mutate.md
![image](https://github.com/user-attachments/assets/f950a23f-2e1b-4160-a02d-044d43f2c6d2)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
