### PR TITLE
Updated documentation for assertion trees

### DIFF
--- a/content/en/docs/kyverno-cli/assertion-trees.md
+++ b/content/en/docs/kyverno-cli/assertion-trees.md
@@ -41,7 +41,7 @@ In the example above the `check` is matching Namespace elements named `hello-wor
 
 ## Examples
 
-Implementation is based on [Kyverno JSON - assertion trees](https://kyverno.github.io/kyverno-json/latest/policies/policies/). Please refer to the documentation for more details on the syntax.
+Implementation is based on [Kyverno JSON - assertion trees](https://kyverno.github.io/kyverno-json/latest/policies/asserts/). Please refer to the documentation for more details on the syntax.
 
 ### Select all results
 


### PR DESCRIPTION
This PR addresses issues in the documentation about Working with assertion trees.
Currently the link in docs point to wrong documentation (policies), which actually should have been "Assertion trees in kyverno-json"

![pr1](https://github.com/user-attachments/assets/6e14eaed-74c1-4635-9f5d-567f6cd0c4d4)

File modified:
content/en/docs/kyverno-cli/assertion-trees.md




