### PR TITLE
Updated documentation for assertion trees

### DIFF
--- a/content/en/docs/kyverno-cli/assertion-trees.md
+++ b/content/en/docs/kyverno-cli/assertion-trees.md
@@ -41,7 +41,7 @@ In the example above the `check` is matching Namespace elements named `hello-wor
 
 ## Examples
 
-Implementation is based on [Kyverno JSON - assertion trees](https://kyverno.github.io/kyverno-json/latest/policies/policies/). Please refer to the documentation for more details on the syntax.
+Implementation is based on [Kyverno JSON - assertion trees](https://kyverno.github.io/kyverno-json/latest/policies/asserts/). Please refer to the documentation for more details on the syntax.
 
 ### Select all results
 


### PR DESCRIPTION
This PR addresses issue in the documentation about Working with assertion trees.
Currently the link in docs point to wrong documentation (policies), which actually should have been "Assertion trees in kyverno-json"

![image](https://github.com/user-attachments/assets/f5185088-c835-4f5a-9645-7b195fc4924f)


File modified:
content/en/docs/kyverno-cli/assertion-trees.md

Checklist
I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
I have inspected the website preview for accuracy.
I have signed off my issue.
