### PR TITLE
Fixed link for kubernetes extension installation

### DIFF
--- a/content/en/docs/CRDs/_index.md
+++ b/content/en/docs/CRDs/_index.md
@@ -64,4 +64,4 @@ FIELDS:
      seconds.
 ```
 
-Kyverno's support for structural schemas also enables integrated help in Kubernetes enabled Integrated Development Environments (IDEs) like [VS Code](https://code.visualstudio.com/) with the [Kubernetes Extension](https://code.visualstudio.com/docs/azure/kubernetes) installed.
+Kyverno's support for structural schemas also enables integrated help in Kubernetes enabled Integrated Development Environments (IDEs) like [VS Code](https://code.visualstudio.com/) with the [Kubernetes Extension](https://code.visualstudio.com/docs/azure/kubernetes#_install-the-kubernetes-extension) installed.


### PR DESCRIPTION
This PR fixes the link for kubernetes extension, which currently points to [https://code.visualstudio.com/docs/azure/kubernetes] instead of https://code.visualstudio.com/docs/azure/kubernetes#_install-the-kubernetes-extension


Changes made to : content/en/docs/CRDs/index.md
![image](https://github.com/user-attachments/assets/b8139ba3-587c-4372-bb90-3b3bbbeccc66)


- [] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [] I have inspected the website preview for accuracy.
- [] I have signed off my issue.
