### PR TITLE
Update cleanup-ttl-controller-deleted-objects.md

### DIFF
--- a/content/en/docs/monitoring/cleanup-ttl-controller-deleted-objects.md
+++ b/content/en/docs/monitoring/cleanup-ttl-controller-deleted-objects.md
@@ -1,5 +1,5 @@
 ---
-title: Cleanup Controller Deleted Objects
+title: Cleanup TTL Controller Deleted Objects
 description: This metric can be used to track the number of objects deleted by the cleanup TTL controller.
 weight: 45
 ---


### PR DESCRIPTION
In the Kyverno Documentation left menu, there is no way to distinguish the "Cleanup Controller Deleted Objects" from the "Cleanup TTL Controller Deleted Objects" as both are described as "Cleanup Controller Deleted Objects". This change would reflect in the left menu what is specific to the TTL controller.

## Related issue #

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [] I have inspected the website preview for accuracy.
- [] I have signed off my issue.
