### PR TITLE
docs: clarify that variables are not allowed in imageReferences field

### DIFF
--- a/content/en/docs/writing-policies/verify-images/_index.md
+++ b/content/en/docs/writing-policies/verify-images/_index.md
@@ -48,6 +48,17 @@ The `imageRegistryCredentials.secrets` specifies a list of secrets that are prov
 
 For additional details please reference a section below for the solution used to sign the images and attestations:
 
+## Limitations
+
+### Variables in `imageReferences`
+The `imageReferences` field does **not** support variable interpolation (e.g., `{{ }}` syntax). Only **static strings** or predefined lists should be used.
+
+#### **Incorrect Usage**
+```yaml
+verifyImages:
+  - imageReferences: ["{{ parse_yaml(allowedregistryprefixes.data.allowedregistryprefixes) }}"]
+
+
 ### Cache
 
 Image verification requires multiple network calls and can be time consuming. Kyverno has a TTL based cache for image verification which caches successful outcomes of image verification. When cache is enabled, an image once verified by a policy will be considered to be verified until TTL duration expires or there is a change in policy.


### PR DESCRIPTION
## Related issue #
#1462 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes
This PR updates the Verify Images documentation to explicitly state that 
variables (`{{ }}` syntax) are not allowed in the `imageReferences` field.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [*] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [*] I have inspected the website preview for accuracy.
- [*] I have signed off my issue.
