### PR TITLE
Updating README with instructions for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ cd kyverno-website
 hugo server
 ```
 
-**Note For Windows Users:** When running the `hugo server` command, make sure to execute it with administrator privileges in your terminal. This is necessary to ensure proper access and functionality during the server execution.
+**Note For Windows Users:** When running the `hugo server` command, make sure to execute it with administrator privileges in your terminal. You can do this by either:
+- Right-clicking on your terminal application (PowerShell/Command Prompt) and selecting "Run as administrator"
+- Or by pressing Windows key + X and selecting "Windows PowerShell (Admin)" or "Command Prompt (Admin)"
+
+Then navigate to your project directory and run the `hugo server` command.
 
 By default, Hugo runs the website at: http://localhost:1313 and will re-build the site on changes.
 


### PR DESCRIPTION
Improves the Windows user instructions in the README by adding detailed steps for running Hugo server with administrator privileges. This change makes it clearer for Windows users how to properly set up their development environment.

## Related issue #
N/A

## Proposed Changes
- Added specific instructions for running terminal as administrator in Windows
- Included two common methods to access administrator privileges
- Maintained consistent documentation style

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- []x I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
