### PR TITLE
docs: add warning about required rbac key in Helm values (fixes #1505…#1506

### DIFF
--- a/content/en/docs/installation/upgrading.md
+++ b/content/en/docs/installation/upgrading.md
@@ -29,6 +29,10 @@ Kyverno version 1.13 contains the following breaking configuration changes:
 
 To upgrade to 1.13 and continue to allow wildcard view permissions for all Kyverno controllers, use a [Helm values file](https://github.com/kyverno/kyverno/blob/v1.13.0/charts/kyverno/values.yaml) that grants these permissions as specified below:
 
+{{% alert title="Important" color="warning" %}}
+Note that the `rbac` key under `admissionController`, `backgroundController`, and `reportsController` is **required** and must not be omitted.
+{{% /alert %}}
+
 ```yaml
 admissionController:
   rbac:


### PR DESCRIPTION
## Related issue #

Fixes #1505 #1506

## Proposed Changes

This PR adds a warning alert to the upgrading documentation to explicitly highlight that the `rbac` key is **required** when configuring RBAC permissions in the Helm values file.

The issues reported that the YAML example was missing the `rbac` key in the hierarchy. The correct structure has already been fixed in the repository, but this PR adds an explicit warning to prevent users from inadvertently omitting the key.

The alert reads:
> Note that the `rbac` key under `admissionController`, `backgroundController`, and `reportsController` is **required** and must not be omitted.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.