### PR TITLE
Fix applying policies link

### DIFF
--- a/content/en/docs/policy-types/cluster-policy/policy-rules/_index.md
+++ b/content/en/docs/policy-types/cluster-policy/policy-rules/_index.md
@@ -22,4 +22,4 @@ Policies can be defined as cluster-wide resources (using the kind `ClusterPolicy
 
 Additional policy types include [Policy Exceptions](/docs/policy-types/cluster-policy/exceptions.md) and [Cleanup Policies](/docs/policy-types/cluster-policy/cleanup.md) which are separate resources and described further in the documentation.
 
-Learn more about [Applying Policies](/doc/applying-policies/_index.md) and [Writing Policies](/docs/policy-types/cluster-policy/_index.md) in the upcoming chapters.
+Learn more about [Applying Policies](/docs/applying-policies/) and [Writing Policies](/docs/policy-types/cluster-policy/_index.md) in the upcoming chapters.


### PR DESCRIPTION
## Related issue #1551

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

This PR fixes the dead link behind 'Applying Policies' in the policy rules documentation. The link was incorrectly using `/doc/applying-policies/_index.md` instead of `/docs/applying-policies/`, which was causing a 404 error. This change ensures users can properly navigate to the applying policies documentation.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.