### PR TITLE
Fix missing documentation for Kyverno 1.14.0

### DIFF
--- a/content/en/docs/installation/methods.md
+++ b/content/en/docs/installation/methods.md
@@ -51,7 +51,7 @@ reportsController:
   replicas: 3
 ```
 
-For all of the available values and their defaults, please see the Helm chart [README](https://github.com/kyverno/kyverno/tree/release-1.13/charts/kyverno). You should carefully inspect all available chart values and their defaults to determine what overrides, if any, are necessary to meet the particular needs of your production environment.
+For all of the available values and their defaults, please see the Helm chart [README](https://github.com/kyverno/kyverno/tree/release-1.14/charts/kyverno). You should carefully inspect all available chart values and their defaults to determine what overrides, if any, are necessary to meet the particular needs of your production environment.
 
 {{% alert title="Note" color="warning" %}}
 All Kyverno installations require the admission controller be among the controllers deployed. For a highly-available installation, at least 2 or more replicas are required. Based on scalability requirements, and cluster topology, additional replicas can be configured for each controller.
@@ -88,7 +88,7 @@ Kyverno can also be installed using a single installation manifest, however for 
 Although Kyverno uses release branches, only YAML manifests from a tagged release are supported. Pull from a tagged release to install Kyverno using the YAML manifest.
 
 ```sh
-kubectl create -f https://github.com/kyverno/kyverno/releases/download/v1.11.1/install.yaml
+kubectl create -f https://github.com/kyverno/kyverno/releases/download/v1.14.0/install.yaml
 ```
 
 ### Testing unreleased code

--- a/content/en/docs/installation/upgrading.md
+++ b/content/en/docs/installation/upgrading.md
@@ -19,6 +19,41 @@ Direct upgrades from previous versions are not supported when using the YAML man
 An upgrade from versions prior to Kyverno 1.10 to versions at 1.10 or higher using Helm requires manual intervention and cannot be performed via a direct upgrade process. Please see the Helm chart v2 to v3 migration guide [here](https://github.com/kyverno/kyverno/blob/release-1.13/charts/kyverno/README.md#migrating-from-v2-to-v3) for more complete information.
 
 
+## Upgrading to Kyverno v1.14
+
+### New Policy Types
+
+Kyverno 1.14 introduces two new policy types:
+
+1. **ValidatingPolicy**: A specialized policy type that focuses on validation with Common Expression Language (CEL) as the primary validation method, aligning with Kubernetes' native `ValidatingAdmissionPolicy`.
+
+2. **ImageValidatingPolicy**: A dedicated policy type that focuses exclusively on container image verification, enhancing software supply chain security capabilities.
+
+These new policy types can be used alongside existing `ClusterPolicy` and `Policy` resources. Transitioning to these new policy types is optional but recommended for better alignment with Kubernetes and simplified policy management.
+
+### Migration Considerations
+
+When upgrading to Kyverno 1.14, consider the following:
+
+1. **Existing Policies**: All existing policies will continue to function as before. There is no requirement to migrate immediately.
+
+2. **New Policies**: For new policy development, consider using the new policy types for better organization and simplified structure.
+
+3. **CRDs**: Ensure you install the updated CRDs which include the new policy types.
+
+### Breaking Changes
+
+While Kyverno 1.14 strives to maintain backward compatibility, be aware of:
+
+1. **Upgraded CEL Support**: The CEL library has been enhanced and may have slight behavior differences in edge cases.
+
+2. **API Changes**: The new policy types introduce new APIs that may require updates to any automation, CI/CD pipelines, or tools interacting with Kyverno policies.
+
+For detailed information about the new policy types, refer to:
+- [ValidatingPolicy Documentation](https://main.kyverno.io/docs/policy-types/validating-policy/)
+- [ImageValidatingPolicy Documentation](https://main.kyverno.io/docs/policy-types/image-validating-policy/)
+
+
 ## Upgrading to Kyverno v1.13
 
 ### Breaking Changes

--- a/content/en/docs/introduction/quick-start.md
+++ b/content/en/docs/introduction/quick-start.md
@@ -12,7 +12,7 @@ These guides are intended for proof-of-concept or lab demonstrations only and no
 First, install Kyverno from the latest release manifest.
 
 ```sh
-kubectl create -f https://github.com/kyverno/kyverno/releases/download/v1.13.0/install.yaml
+kubectl create -f https://github.com/kyverno/kyverno/releases/download/v1.14.0/install.yaml
 ```
 
 Next, select the quick start guide in which you are interested. Alternatively, start at the top and work your way down.


### PR DESCRIPTION
## Related issue #1543

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

This PR adds the missing documentation for Kyverno 1.14.0, specifically:

1. Added a comprehensive section about upgrading to v1.14 in `upgrading.md`, including:
   - Information about the new policy types (ValidatingPolicy and ImageValidatingPolicy)
   - Migration considerations
   - Breaking changes
   - Links to the relevant documentation

2. Updated installation commands in `quick-start.md` and `methods.md` to reference v1.14.0 instead of older versions.

3. Updated the Helm chart README link to point to release-1.14 instead of release-1.13 in `methods.md`.

All changes have been verified by building the site locally.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.