### PR TITLE
fix: correct broken links to Policy Exceptions and Cleanup Policies

### DIFF
--- a/content/en/docs/policy-types/cluster-policy/policy-rules/_index.md
+++ b/content/en/docs/policy-types/cluster-policy/policy-rules/_index.md
@@ -20,6 +20,6 @@ Each rule consists of a [`match`](/docs/policy-types/cluster-policy/match-exclud
 
 Policies can be defined as cluster-wide resources (using the kind `ClusterPolicy`) or namespaced resources (using the kind `Policy`). As expected, namespaced policies will only apply to resources within the namespace in which they are defined while cluster-wide policies are applied to matching resources across all namespaces. Otherwise, there is no difference between the two types.
 
-Additional policy types include [Policy Exceptions](/docs/policy-types/cluster-policy/exceptions.md) and [Cleanup Policies](/docs/policy-types/cluster-policy/cleanup.md) which are separate resources and described further in the documentation.
+Additional policy types include [Policy Exceptions](/docs/exceptions/) and [Cleanup Policies](/docs/policy-types/cleanup-policy/) which are separate resources and described further in the documentation.
 
 Learn more about [Applying Policies](/docs/applying-policies/) and [Writing Policies](/docs/policy-types/cluster-policy/_index.md) in the upcoming chapters.


### PR DESCRIPTION
## Summary

Fixes broken hyperlinks in the policy-rules documentation page that were returning 404 errors.

## Changes Made

- Fixed Policy Exceptions link: `/docs/policy-types/cluster-policy/exceptions.md` → `/docs/exceptions/`
- Fixed Cleanup Policies link: `/docs/policy-types/cluster-policy/cleanup.md` → `/docs/policy-types/cleanup-policy/`

## Verification

- ✅ Both target documentation pages exist and are accessible
- ✅ Codegen completed successfully with no issues
- ✅ No other files were modified

## Test Plan

- [x] Verified target files exist at the corrected paths
- [x] Ran `make codegen` to ensure no issues with generated content
- [x] Confirmed only the intended file was modified

Fixes #1578