### PR TITLE
Fix: kyverno latest release now link to the latest release and not an harcoded one

### DIFF
--- a/content/en/docs/introduction/quick-start.md
+++ b/content/en/docs/introduction/quick-start.md
@@ -12,7 +12,7 @@ These guides are intended for proof-of-concept or lab demonstrations only and no
 First, install Kyverno from the latest release manifest.
 
 ```sh
-kubectl create -f https://github.com/kyverno/kyverno/releases/download/v1.14.2/install.yaml
+kubectl create -f https://github.com/kyverno/kyverno/releases/latest/download/install.yaml
 ```
 
 Next, select the quick start guide in which you are interested. Alternatively, start at the top and work your way down.


### PR DESCRIPTION

## Proposed Changes

In the quick start if we want to install Kyverno in one line, despite the fact that the text says to install the latest release of Kyverno, the command points to 1.13 release

<img width="1423" alt="Capture d’écran 2025-07-01 à 11 40 50" src="https://github.com/user-attachments/assets/bf60a107-d18f-4f38-927a-b55699e18b55" />

So the changes allows to install in one ligne the latest release, not a hardcoded and obsolete version :).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
