### PR TITLE
[docs] imageRegistryCredentials have providers field

### DIFF
--- a/content/en/docs/policy-types/cluster-policy/verify-images/_index.md
+++ b/content/en/docs/policy-types/cluster-policy/verify-images/_index.md
@@ -41,7 +41,7 @@ The `attestors.count` specifies the required count of attestors in the entries l
 
 The `imageRegistryCredentials` attribute allows configuration of registry credentials per policy. Kyverno falls back to global credentials if this is empty.
 
-The `imageRegistryCredentials.helpers` is an array of credential helpers that can be used for this policy. Allowed values are `default`,`google`,`azure`,`amazon`,`github`.
+The `imageRegistryCredentials.providers` is an array of credential helpers that can be used for this policy. Allowed values are `default`,`google`,`azure`,`amazon`,`github`.
 
 The `imageRegistryCredentials.secrets` specifies a list of secrets that are provided for credentials. Secrets must be in the Kyverno namespace.
 


### PR DESCRIPTION
## Related issue #
Closes #1636

## Proposed Changes
Changed the imageRegistryCredentials field from helpers to providers.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [] I have signed off my issue.
