### PR TITLE
Correct broken link to "Cleanup policies" on Applying Policies page

### DIFF
--- a/content/en/docs/applying-policies/_index.md
+++ b/content/en/docs/applying-policies/_index.md
@@ -14,7 +14,7 @@ On installation, Kyverno runs as a [dynamic admission controller](https://kubern
 
 Exceptions to policies may be defined in the rules themselves or with a separate [PolicyException resource](/docs/exceptions).
 
-[Cleanup policies](/docs/policy-types/cluster-policy/cleanup.md), another separate resource type, can be used to remove existing resources based upon a definition and schedule.
+[Cleanup policies](/docs/policy-types/cleanup-policy/), another separate resource type, can be used to remove existing resources based upon a definition and schedule.
 
 ## In Pipelines
 

--- a/content/en/docs/policy-reports/_index.md
+++ b/content/en/docs/policy-reports/_index.md
@@ -250,47 +250,52 @@ timestamp:
 
 ## Report internals
 
-The `PolicyReport` and `ClusterPolicyReport` are the final resources composed of matching resources as determined by Kyverno `Policy` and `ClusterPolicy` objects, however these reports are built of four intermediary resources. For matching resources which were caught during admission mode, `AdmissionReport` and `ClusterAdmissionReport` resources are created. For results of background processing, `BackgroundScanReport` and `ClusterBackgroundScanReport` resources are created. An example of a `ClusterAdmissionReport` is shown below.
+In Kyverno `v1.12` and later, the internal reporting mechanism has been simplified.
+
+The final `PolicyReport` and `ClusterPolicyReport` resources are still used to summarize policy results, but instead of being built from four separate intermediary report types, Kyverno now uses a unified ephemeral report format. These internal reports, called `EphemeralReport` and `ClusterEphemeralReport`, are generated for both admission and background scans. They exist temporarily in memory or briefly in the cluster, and Kyverno uses them to construct the final reports automatically. Users typically do not interact with them directly unless troubleshooting or debugging.
+
+### Example
 
 ```yaml
-apiVersion: kyverno.io/v1alpha2
-kind: ClusterAdmissionReport
+apiVersion: kyverno.io/v2alpha1
+kind: ClusterEphemeralReport
 metadata:
-  creationTimestamp: "2022-10-18T13:15:09Z"
-  generation: 1
+  name: report-ns-team-a-20250808
+  creationTimestamp: "2025-08-08T10:22:30Z"
   labels:
     app.kubernetes.io/managed-by: kyverno
-    audit.kyverno.io/resource.hash: a7ec5160f220c5b83c26b5c8f7dc35b6
-    audit.kyverno.io/resource.uid: 61946422-14ba-4aa2-94b4-229d38446381
-    cpol.kyverno.io/require-ns-labels: "4773"
-  name: c0cc7337-9bcd-4d53-abb2-93f7f5555216
-  resourceVersion: "4986"
-  uid: 10babc6c-9e6e-4386-abed-c13f50091523
+    policy.kyverno.io/name: require-team-label
+    policy.kyverno.io/namespace: ""
+    report.kyverno.io/resource.kind: Namespace
+    report.kyverno.io/resource.name: team-a
+    report.kyverno.io/resource.uid: 4567abcd-89ef-4cde-b123-abcdef123456
 spec:
-  owner:
+  scope:
     apiVersion: v1
     kind: Namespace
-    name: testing
-    uid: 61946422-14ba-4aa2-94b4-229d38446381
+    name: team-a
+    uid: 4567abcd-89ef-4cde-b123-abcdef123456
   results:
-  - message: 'validation error: The label `thisshouldntexist` is required. rule check-for-labels-on-namespace
-      failed at path /metadata/labels/thisshouldntexist/'
-    policy: require-ns-labels
-    result: fail
-    rule: check-for-labels-on-namespace
-    scored: true
-    source: kyverno
-    timestamp:
-      nanos: 0
-      seconds: 1666098909
+    - policy: require-team-label
+      rule: check-team-label
+      result: fail
+      message: 'validation error: The label `team` is required on Namespace.'
+      scored: true
+      source: kyverno
+      timestamp:
+        seconds: 1723111950
+        nanos: 0
   summary:
-    error: 0
-    fail: 1
     pass: 0
-    skip: 0
+    fail: 1
     warn: 0
+    error: 0
+    skip: 0
+
 ```
 
-These intermediary resources have the same basic contents as a policy report and are used internally by Kyverno to build the final policy report. Kyverno will merge these results automatically into the appropriate policy report and there is no manual interaction typically required.
+> **Note:** These reports are ephemeral and exist only in memory or temporarily in the cluster. They are used by Kyverno internally to accumulate rule evaluation results before merging them into final `PolicyReport` or `ClusterPolicyReport` resources. You typically don’t interact with them unless you are debugging policy behavior or inspecting the internal evaluation flow.
 
-For more details on the internal reporting processes, see the developer docs [here](https://github.com/kyverno/kyverno/tree/main/docs/dev/reports).
+### Reference
+
+For developers or advanced users, more technical information about these reports can be found in the [Kyverno developer documentation](https://github.com/kyverno/kyverno/tree/main/docs/dev/reports).

--- a/content/en/docs/policy-reports/background.md
+++ b/content/en/docs/policy-reports/background.md
@@ -14,7 +14,7 @@ spec:
 ```
 
 {{% alert title="Note" color="info" %}}
-Background scans are handled by the reports controller and not the background controller.
+Background scans are handled by the **reports controller**, not the background controller. In Kyverno v1.12 and later, the internal reporting mechanism has been simplified. Instead of four separate intermediary resources (`AdmissionReport`, `ClusterAdmissionReport`, `BackgroundScanReport`, and `ClusterBackgroundScanReport`), Kyverno now uses ephemeral reports (`EphemeralReport` and `ClusterEphemeralReport`) which are short-lived and generated on-the-fly for both admission and background scans. These are used internally by Kyverno to construct the final `PolicyReport` and `ClusterPolicyReport` resources for users.
 {{% /alert %}}
 
 Background scanning, enabled by default in a `Policy` or `ClusterPolicy` object with the `spec.background` field, allows Kyverno to periodically scan existing resources and find if they match any `validate` or `verifyImages` rules. If existing resources are found which would violate an existing policy, the background scan notes them in a `ClusterPolicyReport` or a `PolicyReport` object, depending on if the resource is namespaced or not. It does not block any existing resources that match a rule, even in `Enforce` mode. It has no effect on either `generate` or `mutate` rules for the purposes of reporting.

--- a/content/en/docs/policy-reports/openreports.md
+++ b/content/en/docs/policy-reports/openreports.md
@@ -8,13 +8,13 @@ weight: 15
 
 Kyverno supports reporting policy results using the `openreports.io/v1alpha1` API as an alternative to the default wgpolicyk8s reporting. This can be enabled using the `--openreportsEnabled` flag in the Kyverno controller.
 
-This is an initial step to eventually deprecate `wgpolicyk8s` and fully depend on `openreports.io` as the API group for permanent reports
+This is an initial step to eventually deprecate `wgpolicyk8s` and fully depend on `openreports.io` as the API group for permanent reports.
 
 ### Enabling OpenReports
 
-To enable OpenReports integration, add the `--openreportsEnabled` flag to the Kyverno reports controller.
+To enable OpenReports integration, add the `--enableOpenReports` flag to the Kyverno reports controller.
 
-If you are deploying Kyverno using Helm, setting the chart value `openreports.enabled=true` will automatically add the `--openreportsEnabled` flag to the reports controller deployment.
+If you are deploying Kyverno using Helm, setting the chart value `reportsController.enableOpenReports=true` will automatically add the `--enableOpenReports` flag to the reports controller deployment.
 
 ### Example: Enforcing an 'app' Label
 


### PR DESCRIPTION
## Related issue #
Closes #1645 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

 The link was previously targeting non-existing url:

https://kyverno.io/docs/policy-types/cluster-policy/cleanup.md (404 / internal error)

The correct destination is the Cleanup Policy page:

https://kyverno.io/docs/policy-types/cleanup-policy/

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
