### PR TITLE
Update test.md

### DIFF
--- a/content/en/docs/kyverno-cli/usage/test.md
+++ b/content/en/docs/kyverno-cli/usage/test.md
@@ -325,7 +325,7 @@ Loading test  ( kyverno-test.yaml ) ...
 Test Summary: 2 tests passed and 0 tests failed
 ```
 
-In the below case, a `mutate` policy which adds default resources to a Pod is being tested against two resources. Notice the addition of the `patchedResource` field in the `results[]` array, which is a requirement when testing `mutate` rules.
+In the below case, a `mutate` policy which adds default resources to a Pod is being tested against two resources. Notice the addition of the `patchedResources` field in the `results[]` array, which is a requirement when testing `mutate` rules.
 
 Policy manifest (`add-default-resources.yaml`):
 
@@ -467,7 +467,7 @@ resources:
 targetResources:
 - raw-secret.yaml
 results:
-- patchedResource: mutated-secret.yaml
+- patchedResources: mutated-secret.yaml
   policy: mutate-existing-secret
   resources:
     - secret-1
@@ -1243,7 +1243,7 @@ Test Summary: 6 tests passed and 0 tests failed
 
 #### MutatingAdmissionPolicy
 
-To test a `MutatingAdmissionPolicy`, the test manifest must include the `isMutatingAdmissionPolicy` field set to `true` in the test results array. In addition, the `patchedResource` field must be included to specify the resource that is expected to be patched by the policy.
+To test a `MutatingAdmissionPolicy`, the test manifest must include the `isMutatingAdmissionPolicy` field set to `true` in the test results array. In addition, the `patchedResources` field must be included to specify the resource that is expected to be patched by the policy.
 
 ##### Example 1: Simple Mutation
 


### PR DESCRIPTION
When running `mutated-secret.yaml` test on [this page](https://kyverno.io/docs/kyverno-cli/usage/test/), I encountered the following error:

```
$ kubectl kyverno test .

Test errors:
  Path: kyverno-test.yaml
    Error: error unmarshaling JSON: while decoding JSON: json: unknown field "patchedResource"
Error: found 1 errors after loading tests
```

After reviewing other examples I found that replacing `patchedResource` with `patchedResources` allowed the tests to pass.

(I skipped creating an issue since this was such a quick change, but if I missed something please let me know.)

## Related issue #

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
