### PR TITLE
feat: Update missing links blocking CI

### DIFF
--- a/content/en/blog/general/automating-cis-compliance/index.md
+++ b/content/en/blog/general/automating-cis-compliance/index.md
@@ -203,7 +203,7 @@ kubectl apply -f tests/kind-manifests/noncompliant-pod.yaml
 
 **Critical for Complete CIS Coverage**: kube-bench provides essential validation that Kyverno cannot perform:
 
-**File:** [kube-bench/job-node.yaml](https://github.com/ATIC-Yugandhar/cis-eks-kyverno/blob/main/kube-bench/job-node.yaml)
+**File:** [kube-bench/job-node.yaml](https://github.com/ATIC-Yugandhar/cis-eks-kyverno/blob/d508560478d434921dfe78b28f028348265ec4fa/kube-bench/job-node.yaml)
 
 ```yaml
 apiVersion: batch/v1

--- a/content/en/support/nirmata/_index.md
+++ b/content/en/support/nirmata/_index.md
@@ -23,20 +23,22 @@ type: docs
 {{< youtube id="LvZ66a9UUNM" start="0" class="video" >}}
 {{% /videos %}}
 
-### Nirmata Policy Manager
+### Nirmata Control Hub
 
-[Nirmata Policy Manager](https://nirmata.com/nirmata-cloud-native-policy-manager/) provides centralized visibility and governance across fleets of clusters. It includes:
+[Nirmata Control Hub](https://nirmata.com/nirmata-control-hub/) provides centralized visibility and governance across fleets of clusters. It includes:
 
 * All N4K features
-* Centralized reporting across clusters and clouds
+* AI copilot to automate governance uniformly across any infrastructure
+* Centralized reporting and analytics across clusters and clouds
 * Role-based access controls for teams with OIDC and SAML
 * Auto-assign ownership of violations to teams
-* Customizable alerting and notifications
-* DevSecOps Collaboration Workflows e.g., exception management
-* Auto-remediation with GitOps integrations
-* Pipeline scanning and integrations
-* Continuous Compliance
-* CIS Kubernetes Benchmarks
+* Customizable alerting and notifications via Slack, Jira, and other integrations
+* DevSecOps collaboration workflows with exception management
+* Automated remediation suggestions with GitOps integrations
+* Pipeline scanning and integrations for shift-left security
+* Continuous compliance throughout the development process
+* Software supply chain security with image signature verification
+* Intelligent policy-to-cluster and workload mappings
 
 ### Kyverno Training & Support
 


### PR DESCRIPTION
## Related issue #

CI is currently broken because of missing links: 

```sh
## Errors per input

### Errors in ./content/en/blog/general/automating-cis-compliance/index.md

* [404] [https://github.com/ATIC-Yugandhar/cis-eks-kyverno/blob/main/kube-bench/job-node.yaml](https://github.com/ATIC-Yugandhar/cis-eks-kyverno/blob/main/kube-bench/job-node.yaml) | Network error: Not Found

### Errors in ./content/en/support/nirmata/_index.md

* [404] [https://nirmata.com/nirmata-cloud-native-policy-manager/](https://nirmata.com/nirmata-cloud-native-policy-manager/) | Network error: Not Found
```

## Proposed Changes

This PR fixes both issues by:
- Pinning code to the latest commit at the time of the blog
- Updating Nirmata's Policy-reporter section to be Control-Hub instead.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
