### PR TITLE
fix: search not available on website

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -24,7 +24,7 @@
   publish = "dist"
 
   [context.deploy-preview.environment]
-    NODE_ENV = "development"
+    NODE_ENV = "production"
     ASTRO_ENV = "preview"
     SITE_URL = "$DEPLOY_PRIME_URL"
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "astro": "astro",
     "format:check": "prettier --check .",
     "format:write": "lint-staged",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "dependencies": {
     "@astrojs/markdoc": "^0.15.10",


### PR DESCRIPTION
## Related issue #

- https://github.com/kyverno/website/issues/1735


## Proposed Changes

This PR fixes the search not being enabled in production. This happens because we set the `NODE_ENV` to `dev` when building on netlify. 

## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
