### PR TITLE
feat: Remove useless netlify() adapter

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,7 +9,6 @@ import starlightImageZoom from 'starlight-image-zoom'
 import starlightLinksValidator from 'starlight-links-validator'
 import tailwindcss from '@tailwindcss/vite'
 
-const isDev = import.meta.env.DEV || import.meta.env.MODE === 'development'
 const checkLinksPlugin = process.env.CHECK_LINKS
   ? [
       starlightLinksValidator({
@@ -170,8 +169,6 @@ export default defineConfig({
     react(),
     markdoc(),
   ],
-
-  adapter: isDev ? undefined : netlify(),
   vite: {
     plugins: [tailwindcss()],
   },


### PR DESCRIPTION
## Description

We are currently using the `netlify()` adapter because we had planned to use it for SSR (eg: for custom pages like policy library) and image caching, but for now this is useless and error-prone, let's remove it.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
