### PR TITLE
fix: outdated NamespacedDeletingPolicy version

### DIFF
--- a/src/content/docs/docs/policy-types/cel-policies/deleting-policy.mdx
+++ b/src/content/docs/docs/policy-types/cel-policies/deleting-policy.mdx
@@ -80,7 +80,7 @@ Both policy types have identical functionality and field structure. The only dif
 ### Example NamespacedDeletingPolicy
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1beta1
 kind: NamespacedDeletingPolicy
 metadata:
   name: cleanup-jobs
@@ -94,7 +94,7 @@ spec:
         resources: ['jobs']
   conditions:
     - name: 'completed-jobs'
-      expression: "object.status.conditions[?type=='Complete'].status == 'True'"
+      expression: "object.status.conditions.exists(c, c.type == 'Complete' && c.status == 'True')"
 ```
 
 As the name suggests, the `NamespacedDeletingPolicy` allows namespace owners to manage deletion policies without requiring cluster-admin permissions, improving multi-tenancy and security isolation.


### PR DESCRIPTION
## Description

Fixes the NamespacedDeletingPolicy documentation example which contains two critical issues that prevent the example from working.

## Proposed Changes

1. Updated API version from `v1alpha1` to `v1beta1`
   - The v1alpha1 API version does not exist for the required service
   - Users attempting to apply the policy receive: `no matches for kind "NamespacedDeletingPolicy" in version "policies.kyverno.io/v1alpha1"`

2. Fixed CEL expression syntax
   - **Before:** `object.status.conditions[?type=='Complete'].status == 'True'` (JSONPath syntax)
   - **After:** `object.status.conditions.exists(c, c.type == 'Complete' && c.status == 'True')` (valid CEL)
   - The previous expression used JSONPath filter syntax which is not valid in CEL and causes compilation errors

## Testing

Tested the corrected example in a Kind cluster with Kyverno v1.16.0:
- Applied the policy with v1beta1 API version - success
- Created a completed Kubernetes Job
- Policy automatically detected and deleted the completed job within the scheduled interval (1 minute for testing) 
- Verified cleanup controller logs show no compilation errors

## Related Issue

Resolves issue #1784

## Checklist 

 [x] I have read the contributing guidelines.
 [x] I have inspected the website preview for accuracy.
 [x] I have signed off my issue.
 [x] Documentation builds successfully