### PR TITLE
add K8s mode and move version before buttons

### DIFF
--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -60,6 +60,7 @@ export const TopNav = () => {
             className="hidden xl:flex xl:text-lg justify-center space-x-6 
                     items-center"
           >
+            <VersionDropdown />
             <Button
               href="https://playground.kyverno.io/"
               variant="secondary"
@@ -72,7 +73,6 @@ export const TopNav = () => {
             <Button href="/support" variant="accent" size="large">
               Support
             </Button>
-            <VersionDropdown />
           </div>
           <div className="xl:hidden flex flex-col justify-end">
             <button onClick={toggleMobileNav}>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -262,6 +262,8 @@ kind: ValidatingPolicy
 metadata:
   name: require-labels
 spec:
+  evaluation:
+    mode: "Kubernetes"
   matchConstraints:
     resourceRules:
       - apiGroups:   [""]
@@ -318,7 +320,7 @@ metadata:
   name: check-label-maintainer
 spec:
   evaluation:
-    mode: JSON
+    mode: "JSON"
   matchConditions:
     - name: isDockerfile
       expression: "has(object.Stages)"


### PR DESCRIPTION
## Related issue

Minor enhancements

## Proposed Changes

1. Add "mode: Kubernetes" for consistency in policy showcase
2. Move version dropdown before buttons

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
