### PR TITLE
Fix broken link to Cleanup Policy in Applying Policies page  Fix issu…

### DIFF
--- a/src/content/docs/docs/applying-policies/index.md
+++ b/src/content/docs/docs/applying-policies/index.md
@@ -15,7 +15,7 @@ On installation, Kyverno runs as a [dynamic admission controller](https://kubern
 
 Exceptions to policies may be defined in the rules themselves or with a separate [PolicyException resource](/docs/exceptions).
 
-[Cleanup policies](/docs/policy-types/cel-policies/cleanup-policy), another separate resource type, can be used to remove existing resources based upon a definition and schedule.
+[Cleanup policies](/docs/policy-types/cleanup-policy/), another separate resource type, can be used to remove existing resources based upon a definition and schedule.
 
 ## In Pipelines
 


### PR DESCRIPTION
…e #1645: Change link from /docs/policy-types/cel-policies/cleanup-policy to /docs/policy-types/cleanup-policy/ on the Applying Policies documentation page.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [] I have inspected the website preview for accuracy.
- [] I have signed off my issue.
