### PR TITLE
Fix: update image-based exception example to match spec

### DIFF
--- a/src/content/docs/docs/guides/exceptions.md
+++ b/src/content/docs/docs/guides/exceptions.md
@@ -864,7 +864,7 @@ spec:
   policyRefs:
     - name: restrict-image-tag
       kind: ValidatingPolicy
-  images:
+  allowedImages:
     - 'ghcr.io/kyverno/*:latest'
   matchConditions:
     - expression: "has(object.metadata.labels.team) && object.metadata.labels.team == 'platform'"


### PR DESCRIPTION
## PR description:
This PR updates the image-based exception YAML example to use the correct field name (allowedImages) and keeps it consistent with the documented specification.

## Related issue
Resolves #1813 

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes
- Updated the image-based exception YAML example to use allowedImages instead of images.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
