### PR TITLE
Bug Fix (UI): duplicate title, syntax highlighting, spacing

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -25,6 +25,16 @@ export default defineConfig({
     starlight({
       title: 'Kyverno',
       customCss: ['./src/styles/global.css'],
+      expressiveCode: {
+        themes: ['github-dark', 'github-light'],
+        styleOverrides: {
+          borderRadius: '0.5rem',
+          codeFontSize: '0.875rem',
+          codeLineHeight: '1.5',
+        },
+        // Map CEL to YAML for better syntax highlighting (supports # comments)
+        langMappings: { cel: 'yaml' },
+      },
       components: {
         PageSidebar: './src/components/PageSidebar.astro',
         ThemeSelect: './src/components/ThemeSelect.astro',

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -281,8 +281,7 @@ spec:
     -  message: "Pods must have 'app' and 'version' labels"
        expression: |
          has(variables.labels.app) && 
-         has(variables.labels.version)
-     `,
+         has(variables.labels.version)`,
   },
   {
     id: 'validate-terraform',

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -87,6 +87,26 @@
   }
 }
 
+/* Reduce gap between page title and first content paragraph */
+.sl-markdown-content {
+  margin-top: 0 !important;
+}
+
+.content-panel > :first-child {
+  margin-top: 0 !important;
+}
+
+/* Target Starlight's header/title area */
+header.sl-markdown-content,
+.sl-markdown-content > :first-child {
+  margin-top: 0 !important;
+}
+
+/* Reduce the content area top margin */
+[data-pagefind-body] {
+  margin-top: 0.5rem !important;
+}
+
 @layer starlight {
   /* 
    * Restore browser default styles for markdown content that were removed by Tailwind's preflight.


### PR DESCRIPTION
## Fixed several frontend issues in the documentation:

**Duplicate page titles:** Removed redundant # Heading in markdown files where [title](vscode-file://vscode-app/Users/dakshpathak/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is already set in frontmatter
**CEL syntax highlighting:** Configured [expressiveCode](vscode-file://vscode-app/Users/dakshpathak/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to map [cel](vscode-file://vscode-app/Users/dakshpathak/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) language to yaml for proper code block highlighting
**Title-content spacing:** Added CSS to reduce excessive gap between page title and first paragraph
**Removed description subtitles:** Cleaned up frontmatter description fields that caused extra spacing in the UI


Before:
<img width="1703" height="597" alt="image" src="https://github.com/user-attachments/assets/9606e9e2-dfb6-484c-b33a-c3c4aa0ee53d" />

After:
<img width="1563" height="487" alt="image" src="https://github.com/user-attachments/assets/37fafb0a-0e77-4314-a252-6df7507d9147" />

