### PR TITLE
fix: correct typo in image-based exception YAML example

### DIFF
--- a/src/content/docs/docs/guides/exceptions.md
+++ b/src/content/docs/docs/guides/exceptions.md
@@ -864,7 +864,7 @@ spec:
   policyRefs:
     - name: restrict-image-tag
       kind: ValidatingPolicy
-  images:
+  allowedImages:
     - 'ghcr.io/kyverno/*:latest'
   matchConditions:
     - expression: "has(object.metadata.labels.team) && object.metadata.labels.team == 'platform'"


### PR DESCRIPTION
## Related issue

Fixes #1813

## Proposed Changes

Changed the field name from `images:` to `allowedImages:` in the PolicyException YAML example in the Image-based exceptions section to match the field name used in the ValidatingPolicy example.

File changed: `src/content/docs/docs/guides/exceptions.md`

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.