### PR TITLE
docs: upgrade CEL policy samples to policies.kyverno.io/v1

### DIFF
--- a/src/content/docs/docs/guides/exceptions.md
+++ b/src/content/docs/docs/guides/exceptions.md
@@ -472,7 +472,7 @@ Since Kyverno 1.14.0, **PolicyExceptions**, introduced in the new group `policie
 The following `ValidatingPolicy` enforce that all `Deployment` resources must include the label `env=prod`. If this condition is not met, the policy denies the request.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-prod-label
@@ -494,7 +494,7 @@ spec:
 To exclude a specific `Deployment` from the above policy enforcement, a `PolicyException` can be defined. This example uses a CEL expression to match the `Deployment` named `skipped-deployment`, allowing it to bypass the validation.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: PolicyException
 metadata:
   name: exclude-skipped-deployment
@@ -573,7 +573,7 @@ spec:
 The `ImageValidatingPolicy` shown below is configured to run only during background scans, not during admission. It targets Pod resources have the label `prod: true`. When such a resource is encountered, the policy performs three layers of validation: it verifies the image signature using a provided notary certificate, checks for the presence of an SBOM attestation of type `CycloneDX`, and confirms that the payload format matches the expected structure.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ImageValidatingPolicy
 metadata:
   name: ivpol-sample
@@ -628,7 +628,7 @@ spec:
 This `PolicyException` is defined to exempt this pod from enforcement. The exception uses a CEL `expression—object.metadata.name == 'skipped-pod'`to identify the specific resource. It links to the `ImageValidatingPolicy` named `ivpol-sample`, and when the reports controller processes the pod, it detects that the exception applies. As a result, none of the image validation rules are executed for this resource.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: PolicyException
 metadata:
   name: check-name
@@ -692,7 +692,7 @@ This enables fine-grained, declarative exemptions without modifying the core pol
 The following `GeneratingPolicy` is designed to automatically create a ConfigMap named `zk-kafka-address` in any newly created Namespace.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: generate-configmap
@@ -729,7 +729,7 @@ spec:
 To prevent this `ConfigMap` from being created in a specific namespace (e.g., a "testing" namespace), we can define a `PolicyException`. This exception uses a CEL expression to match any Namespace with the name `testing` and skips the `generate-configmap` policy for it.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: PolicyException
 metadata:
   name: exclude-namespace-by-name

--- a/src/content/docs/docs/introduction/quick-start.md
+++ b/src/content/docs/docs/introduction/quick-start.md
@@ -10,7 +10,7 @@ This section is intended to provide you with some quick guides on how to get Kyv
 
 These guides are intended for proof-of-concept or lab demonstrations only and not recommended as a guide for production. Please see the [installation page](/docs/installation/installation) for more complete information on how to install Kyverno in production.
 
-First, install the latest Kyverno release using Helm:
+First,install the latest Kyverno release using Helm:
 
 ```sh
 helm repo add kyverno https://kyverno.github.io/kyverno/
@@ -26,9 +26,13 @@ In the validation guide, you will see how simple an example Kyverno policy can b
 
 Add the policy below to your cluster. It contains a single validation rule that requires that all Pods have the `team` label. Kyverno supports different policy types to validate, mutate, generate, cleanup, and verify image configurations. The `validationActions` field is set to `Deny` to block Pods that are non-compliant.
 
+:::note[Version Note]
+This policy uses `policies.kyverno.io/v1` and requires Kyverno v1.12 or later.
+:::
+
 ```sh
 kubectl create -f- << EOF
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-labels
@@ -133,7 +137,7 @@ Add this Kyverno mutate policy to your cluster. This policy will add the label `
 
 ```sh
 kubectl create -f- << EOF
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-labels
@@ -261,7 +265,7 @@ Next, create the following Kyverno policy. The `sync-secrets` policy will match 
 
 ```sh
 kubectl create -f- << EOF
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: sync-secrets

--- a/src/content/docs/docs/subprojects/kyverno-cli.mdx
+++ b/src/content/docs/docs/subprojects/kyverno-cli.mdx
@@ -1344,7 +1344,7 @@ First, we define a `ValidatingPolicy` that ensures any `Deployment` has no more 
 Policy manifest (check-deployment-replicas.yaml):
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-deployment-replicas
@@ -1479,7 +1479,7 @@ First, we define a `ValidatingPolicy` that uses `resource.Get()` to fetch a Conf
 Policy manifest (check-pod-name-from-configmap.yaml):
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-pod-name-from-configmap
@@ -1617,7 +1617,7 @@ In this example, we will test a policy that disallows `hostPath` volumes, but we
 Policy manifest (disallow-host-path.yaml):
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-path
@@ -1657,7 +1657,7 @@ Now, we create a PolicyException to exempt our specific Pod from this policy. Th
 Policy Exception manifest (exception.yaml):
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: PolicyException
 metadata:
   name: exempt-hostpath-pod
@@ -3231,7 +3231,7 @@ Below is an example of testing a ValidatingPolicy against two resources, one of 
 Policy manifest (check-deployment-replicas.yaml):
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-deployment-replicas
@@ -3347,7 +3347,7 @@ Let's start with a policy that disallows creating certain Deployments in the `de
 Policy manifest (`disallow-default-deployment.yaml`):
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-deployment-namespace
@@ -3557,7 +3557,7 @@ Policy manifest (`check-pod-name-from-configmap.yaml`):
 
 ```yaml
 # policy.yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-pod-name-from-configmap

--- a/src/content/policies/best-practices-gpol/add-network-policy/add-network-policy.md
+++ b/src/content/policies/best-practices-gpol/add-network-policy/add-network-policy.md
@@ -18,7 +18,7 @@ createdAt: "2025-11-04T10:13:04.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/best-practices-gpol/add-network-policy/add-network-policy.yaml" target="-blank">/best-practices-gpol/add-network-policy/add-network-policy.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: add-networkpolicy

--- a/src/content/policies/best-practices-gpol/add-ns-quota/add-ns-quota.md
+++ b/src/content/policies/best-practices-gpol/add-ns-quota/add-ns-quota.md
@@ -19,7 +19,7 @@ createdAt: "2025-11-04T10:13:04.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/best-practices-gpol/add-ns-quota/add-ns-quota.yaml" target="-blank">/best-practices-gpol/add-ns-quota/add-ns-quota.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: add-ns-quota

--- a/src/content/policies/best-practices-gpol/add-rolebinding/add-rolebinding.md
+++ b/src/content/policies/best-practices-gpol/add-rolebinding/add-rolebinding.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-04T10:13:04.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/best-practices-gpol/add-rolebinding/add-rolebinding.yaml" target="-blank">/best-practices-gpol/add-rolebinding/add-rolebinding.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: add-rolebinding

--- a/src/content/policies/best-practices-mpol/add-safe-to-evict/add-safe-to-evict.md
+++ b/src/content/policies/best-practices-mpol/add-safe-to-evict/add-safe-to-evict.md
@@ -18,7 +18,7 @@ createdAt: "2025-10-30T08:57:55.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/best-practices-mpol/add-safe-to-evict/add-safe-to-evict.yaml" target="-blank">/best-practices-mpol/add-safe-to-evict/add-safe-to-evict.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-safe-to-evict

--- a/src/content/policies/castai-mpol/add-castai-removal-disabled/add-castai-removal-disabled.md
+++ b/src/content/policies/castai-mpol/add-castai-removal-disabled/add-castai-removal-disabled.md
@@ -18,7 +18,7 @@ createdAt: "2025-10-30T08:57:55.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/castai-mpol/add-castai-removal-disabled/add-castai-removal-disabled.yaml" target="-blank">/castai-mpol/add-castai-removal-disabled/add-castai-removal-disabled.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-castai-removal-disabled

--- a/src/content/policies/cleanup-dpol/cleanup-bare-pods/cleanup-bare-pods.md
+++ b/src/content/policies/cleanup-dpol/cleanup-bare-pods/cleanup-bare-pods.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-04T10:13:04.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/cleanup-dpol/cleanup-bare-pods/cleanup-bare-pods.yaml" target="-blank">/cleanup-dpol/cleanup-bare-pods/cleanup-bare-pods.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: DeletingPolicy
 metadata:
   name: clean-bare-pods

--- a/src/content/policies/cleanup-dpol/cleanup-empty-replicasets/cleanup-empty-replicasets.md
+++ b/src/content/policies/cleanup-dpol/cleanup-empty-replicasets/cleanup-empty-replicasets.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-04T10:13:04.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/cleanup-dpol/cleanup-empty-replicasets/cleanup-empty-replicasets.yaml" target="-blank">/cleanup-dpol/cleanup-empty-replicasets/cleanup-empty-replicasets.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: DeletingPolicy
 metadata:
   name: cleanup-empty-replicasets

--- a/src/content/policies/istio-mpol/add-ambient-mode-namespace/add-ambient-mode-namespace.md
+++ b/src/content/policies/istio-mpol/add-ambient-mode-namespace/add-ambient-mode-namespace.md
@@ -17,7 +17,7 @@ createdAt: "2025-10-30T08:57:55.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/istio-mpol/add-ambient-mode-namespace/add-ambient-mode-namespace.yaml" target="-blank">/istio-mpol/add-ambient-mode-namespace/add-ambient-mode-namespace.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-ambient-mode-namespace

--- a/src/content/policies/istio-mpol/add-sidecar-injection-namespace/add-sidecar-injection-namespace.md
+++ b/src/content/policies/istio-mpol/add-sidecar-injection-namespace/add-sidecar-injection-namespace.md
@@ -17,7 +17,7 @@ createdAt: "2025-10-30T08:57:55.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/istio-mpol/add-sidecar-injection-namespace/add-sidecar-injection-namespace.yaml" target="-blank">/istio-mpol/add-sidecar-injection-namespace/add-sidecar-injection-namespace.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-sidecar-injection-namespace

--- a/src/content/policies/karpenter-mpol/add-karpenter-daemonset-priority-class/add-karpenter-daemonset-priority-class.md
+++ b/src/content/policies/karpenter-mpol/add-karpenter-daemonset-priority-class/add-karpenter-daemonset-priority-class.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-14T18:23:14.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/karpenter-mpol/add-karpenter-daemonset-priority-class/add-karpenter-daemonset-priority-class.yaml" target="-blank">/karpenter-mpol/add-karpenter-daemonset-priority-class/add-karpenter-daemonset-priority-class.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-karpenter-daemonset-priority-class

--- a/src/content/policies/karpenter-mpol/add-karpenter-donot-evict/add-karpenter-donot-evict.md
+++ b/src/content/policies/karpenter-mpol/add-karpenter-donot-evict/add-karpenter-donot-evict.md
@@ -16,7 +16,7 @@ createdAt: "2025-10-30T07:20:03.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/karpenter-mpol/add-karpenter-donot-evict/add-karpenter-donot-evict.yaml" target="-blank">/karpenter-mpol/add-karpenter-donot-evict/add-karpenter-donot-evict.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-karpenter-donot-evict

--- a/src/content/policies/karpenter-mpol/add-karpenter-nodeselector/add-karpenter-nodeselector.md
+++ b/src/content/policies/karpenter-mpol/add-karpenter-nodeselector/add-karpenter-nodeselector.md
@@ -18,7 +18,7 @@ createdAt: "2025-11-14T18:23:14.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/karpenter-mpol/add-karpenter-nodeselector/add-karpenter-nodeselector.yaml" target="-blank">/karpenter-mpol/add-karpenter-nodeselector/add-karpenter-nodeselector.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-karpenter-nodeselector

--- a/src/content/policies/karpenter-mpol/set-karpenter-non-cpu-limits/set-karpenter-non-cpu-limits.md
+++ b/src/content/policies/karpenter-mpol/set-karpenter-non-cpu-limits/set-karpenter-non-cpu-limits.md
@@ -23,7 +23,7 @@ createdAt: "2025-11-14T18:23:14.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/karpenter-mpol/set-karpenter-non-cpu-limits/set-karpenter-non-cpu-limits.yaml" target="-blank">/karpenter-mpol/set-karpenter-non-cpu-limits/set-karpenter-non-cpu-limits.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: set-karpenter-non-cpu-limits

--- a/src/content/policies/kubecost-mpol/enable-kubecost-continuous-rightsizing/enable-kubecost-continuous-rightsizing.md
+++ b/src/content/policies/kubecost-mpol/enable-kubecost-continuous-rightsizing/enable-kubecost-continuous-rightsizing.md
@@ -17,7 +17,7 @@ createdAt: "2025-10-30T08:57:55.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/kubecost-mpol/enable-kubecost-continuous-rightsizing/enable-kubecost-continuous-rightsizing.yaml" target="-blank">/kubecost-mpol/enable-kubecost-continuous-rightsizing/enable-kubecost-continuous-rightsizing.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: enable-kubecost-continuous-rightsizing

--- a/src/content/policies/kubevirt-gpol/add-services/add-services.md
+++ b/src/content/policies/kubevirt-gpol/add-services/add-services.md
@@ -16,7 +16,7 @@ createdAt: "2025-11-04T10:13:04.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/kubevirt-gpol/add-services/add-services.yaml" target="-blank">/kubevirt-gpol/add-services/add-services.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: k6t-add-services

--- a/src/content/policies/linkerd-mpol/add-linkerd-mesh-injection/add-linkerd-mesh-injection.md
+++ b/src/content/policies/linkerd-mpol/add-linkerd-mesh-injection/add-linkerd-mesh-injection.md
@@ -17,7 +17,7 @@ createdAt: "2025-10-30T08:57:55.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/linkerd-mpol/add-linkerd-mesh-injection/add-linkerd-mesh-injection.yaml" target="-blank">/linkerd-mpol/add-linkerd-mesh-injection/add-linkerd-mesh-injection.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-linkerd-mesh-injection

--- a/src/content/policies/linkerd-mpol/add-linkerd-policy-annotation/add-linkerd-policy-annotation.md
+++ b/src/content/policies/linkerd-mpol/add-linkerd-policy-annotation/add-linkerd-policy-annotation.md
@@ -17,7 +17,7 @@ createdAt: "2025-10-30T08:57:55.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/linkerd-mpol/add-linkerd-policy-annotation/add-linkerd-policy-annotation.yaml" target="-blank">/linkerd-mpol/add-linkerd-policy-annotation/add-linkerd-policy-annotation.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-linkerd-policy-annotation

--- a/src/content/policies/other-gpol/create-default-pdb/create-default-pdb.md
+++ b/src/content/policies/other-gpol/create-default-pdb/create-default-pdb.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-04T10:13:04.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-gpol/create-default-pdb/create-default-pdb.yaml" target="-blank">/other-gpol/create-default-pdb/create-default-pdb.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: create-default-pdb

--- a/src/content/policies/other-mpol/add-certificates-volume/add-certificates-volume.md
+++ b/src/content/policies/other-mpol/add-certificates-volume/add-certificates-volume.md
@@ -18,7 +18,7 @@ createdAt: "2025-10-29T09:59:30.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/add-certificates-volume/add-certificates-volume.yaml" target="-blank">/other-mpol/add-certificates-volume/add-certificates-volume.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-certificates-volume

--- a/src/content/policies/other-mpol/add-default-resources/add-default-resources.md
+++ b/src/content/policies/other-mpol/add-default-resources/add-default-resources.md
@@ -13,7 +13,7 @@ createdAt: "2025-10-29T09:59:30.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/add-default-resources/add-default-resources.yaml" target="-blank">/other-mpol/add-default-resources/add-default-resources.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-default-resources

--- a/src/content/policies/other-mpol/add-default-securitycontext/add-default-securitycontext.md
+++ b/src/content/policies/other-mpol/add-default-securitycontext/add-default-securitycontext.md
@@ -17,7 +17,7 @@ createdAt: "2025-10-29T09:59:30.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/add-default-securitycontext/add-default-securitycontext.yaml" target="-blank">/other-mpol/add-default-securitycontext/add-default-securitycontext.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-default-securitycontext

--- a/src/content/policies/other-mpol/add-emptydir-sizelimit/add-emptydir-sizelimit.md
+++ b/src/content/policies/other-mpol/add-emptydir-sizelimit/add-emptydir-sizelimit.md
@@ -17,7 +17,7 @@ createdAt: "2025-10-29T09:59:30.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/add-emptydir-sizelimit/add-emptydir-sizelimit.yaml" target="-blank">/other-mpol/add-emptydir-sizelimit/add-emptydir-sizelimit.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-emptydir-sizelimit

--- a/src/content/policies/other-mpol/add-env-vars-from-cm/add-env-vars-from-cm.md
+++ b/src/content/policies/other-mpol/add-env-vars-from-cm/add-env-vars-from-cm.md
@@ -17,7 +17,7 @@ createdAt: "2025-10-29T09:59:30.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/add-env-vars-from-cm/add-env-vars-from-cm.yaml" target="-blank">/other-mpol/add-env-vars-from-cm/add-env-vars-from-cm.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-env-vars-from-cm

--- a/src/content/policies/other-mpol/add-image-as-env-var/add-image-as-env-var.md
+++ b/src/content/policies/other-mpol/add-image-as-env-var/add-image-as-env-var.md
@@ -16,7 +16,7 @@ createdAt: "2025-10-29T09:59:30.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/add-image-as-env-var/add-image-as-env-var.yaml" target="-blank">/other-mpol/add-image-as-env-var/add-image-as-env-var.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-image-as-env-var

--- a/src/content/policies/other-mpol/add-imagepullsecrets-for-containers-and-initcontainers/add-imagepullsecrets-for-containers-and-initcontainers.md
+++ b/src/content/policies/other-mpol/add-imagepullsecrets-for-containers-and-initcontainers/add-imagepullsecrets-for-containers-and-initcontainers.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-04T10:13:04.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/add-imagepullsecrets-for-containers-and-initcontainers/add-imagepullsecrets-for-containers-and-initcontainers.yaml" target="-blank">/other-mpol/add-imagepullsecrets-for-containers-and-initcontainers/add-imagepullsecrets-for-containers-and-initcontainers.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-imagepullsecrets-for-containers-and-initcontainers

--- a/src/content/policies/other-mpol/add-imagepullsecrets/add-imagepullsecrets.md
+++ b/src/content/policies/other-mpol/add-imagepullsecrets/add-imagepullsecrets.md
@@ -16,7 +16,7 @@ createdAt: "2025-11-04T10:13:04.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/add-imagepullsecrets/add-imagepullsecrets.yaml" target="-blank">/other-mpol/add-imagepullsecrets/add-imagepullsecrets.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-imagepullsecrets

--- a/src/content/policies/other-mpol/add-labels/add-labels.md
+++ b/src/content/policies/other-mpol/add-labels/add-labels.md
@@ -17,7 +17,7 @@ createdAt: "2025-10-29T09:59:30.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/add-labels/add-labels.yaml" target="-blank">/other-mpol/add-labels/add-labels.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-labels

--- a/src/content/policies/other-mpol/add-ndots/add-ndots.md
+++ b/src/content/policies/other-mpol/add-ndots/add-ndots.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-04T10:13:04.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/add-ndots/add-ndots.yaml" target="-blank">/other-mpol/add-ndots/add-ndots.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-ndots

--- a/src/content/policies/other-mpol/add-nodeSelector/add-nodeSelector.md
+++ b/src/content/policies/other-mpol/add-nodeSelector/add-nodeSelector.md
@@ -17,7 +17,7 @@ createdAt: "2025-10-30T07:20:03.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/add-nodeSelector/add-nodeSelector.yaml" target="-blank">/other-mpol/add-nodeSelector/add-nodeSelector.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-nodeselector

--- a/src/content/policies/other-mpol/add-pod-priorityclassname/add-pod-priorityclassname.md
+++ b/src/content/policies/other-mpol/add-pod-priorityclassname/add-pod-priorityclassname.md
@@ -17,7 +17,7 @@ createdAt: "2025-10-30T07:20:03.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/add-pod-priorityclassname/add-pod-priorityclassname.yaml" target="-blank">/other-mpol/add-pod-priorityclassname/add-pod-priorityclassname.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-pod-priorityclassname

--- a/src/content/policies/other-mpol/add-pod-proxies/add-pod-proxies.md
+++ b/src/content/policies/other-mpol/add-pod-proxies/add-pod-proxies.md
@@ -17,7 +17,7 @@ createdAt: "2025-10-30T07:20:03.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/add-pod-proxies/add-pod-proxies.yaml" target="-blank">/other-mpol/add-pod-proxies/add-pod-proxies.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-pod-proxies

--- a/src/content/policies/other-mpol/add-tolerations/add-tolerations.md
+++ b/src/content/policies/other-mpol/add-tolerations/add-tolerations.md
@@ -17,7 +17,7 @@ createdAt: "2025-10-30T07:20:03.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/add-tolerations/add-tolerations.yaml" target="-blank">/other-mpol/add-tolerations/add-tolerations.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-tolerations

--- a/src/content/policies/other-mpol/add-ttl-jobs/add-ttl-jobs.md
+++ b/src/content/policies/other-mpol/add-ttl-jobs/add-ttl-jobs.md
@@ -17,7 +17,7 @@ createdAt: "2025-10-30T07:20:03.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/add-ttl-jobs/add-ttl-jobs.yaml" target="-blank">/other-mpol/add-ttl-jobs/add-ttl-jobs.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-ttl-jobs

--- a/src/content/policies/other-mpol/add-volume-deployment/add-volume-deployment.md
+++ b/src/content/policies/other-mpol/add-volume-deployment/add-volume-deployment.md
@@ -18,7 +18,7 @@ createdAt: "2025-10-30T07:20:03.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/add-volume-deployment/add-volume-deployment.yaml" target="-blank">/other-mpol/add-volume-deployment/add-volume-deployment.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-volume

--- a/src/content/policies/other-mpol/always-pull-images/always-pull-images.md
+++ b/src/content/policies/other-mpol/always-pull-images/always-pull-images.md
@@ -17,7 +17,7 @@ createdAt: "2025-10-30T07:20:03.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/always-pull-images/always-pull-images.yaml" target="-blank">/other-mpol/always-pull-images/always-pull-images.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: always-pull-images

--- a/src/content/policies/other-mpol/annotate-base-images/annotate-base-images.md
+++ b/src/content/policies/other-mpol/annotate-base-images/annotate-base-images.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-14T18:23:14.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/annotate-base-images/annotate-base-images.yaml" target="-blank">/other-mpol/annotate-base-images/annotate-base-images.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: annotate-base-images

--- a/src/content/policies/other-mpol/apply-pss-restricted-profile/apply-pss-restricted-profile.md
+++ b/src/content/policies/other-mpol/apply-pss-restricted-profile/apply-pss-restricted-profile.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-04T10:13:04.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/apply-pss-restricted-profile/apply-pss-restricted-profile.yaml" target="-blank">/other-mpol/apply-pss-restricted-profile/apply-pss-restricted-profile.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: apply-pss-restricted-profile

--- a/src/content/policies/other-mpol/disable-automountserviceaccounttoken/disable-automountserviceaccounttoken.md
+++ b/src/content/policies/other-mpol/disable-automountserviceaccounttoken/disable-automountserviceaccounttoken.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-18T07:36:13.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/disable-automountserviceaccounttoken/disable-automountserviceaccounttoken.yaml" target="-blank">/other-mpol/disable-automountserviceaccounttoken/disable-automountserviceaccounttoken.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: disable-automountserviceaccounttoken

--- a/src/content/policies/other-mpol/disable-service-discovery/disable-service-discovery.md
+++ b/src/content/policies/other-mpol/disable-service-discovery/disable-service-discovery.md
@@ -18,7 +18,7 @@ createdAt: "2025-10-30T07:20:03.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/disable-service-discovery/disable-service-discovery.yaml" target="-blank">/other-mpol/disable-service-discovery/disable-service-discovery.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: disable-service-discovery

--- a/src/content/policies/other-mpol/inject-sidecar-deployment/inject-sidecar-deployment.md
+++ b/src/content/policies/other-mpol/inject-sidecar-deployment/inject-sidecar-deployment.md
@@ -18,7 +18,7 @@ createdAt: "2025-11-14T18:23:14.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/inject-sidecar-deployment/inject-sidecar-deployment.yaml" target="-blank">/other-mpol/inject-sidecar-deployment/inject-sidecar-deployment.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: inject-sidecar

--- a/src/content/policies/other-mpol/label-existing-namespaces/label-existing-namespaces.md
+++ b/src/content/policies/other-mpol/label-existing-namespaces/label-existing-namespaces.md
@@ -16,7 +16,7 @@ createdAt: "2025-11-18T07:36:13.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/label-existing-namespaces/label-existing-namespaces.yaml" target="-blank">/other-mpol/label-existing-namespaces/label-existing-namespaces.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: label-existing-namespaces

--- a/src/content/policies/other-mpol/label-nodes-cri/label-nodes-cri.md
+++ b/src/content/policies/other-mpol/label-nodes-cri/label-nodes-cri.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-18T07:36:13.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/label-nodes-cri/label-nodes-cri.yaml" target="-blank">/other-mpol/label-nodes-cri/label-nodes-cri.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: label-nodes-cri

--- a/src/content/policies/other-mpol/mitigate-log4shell/mitigate-log4shell.md
+++ b/src/content/policies/other-mpol/mitigate-log4shell/mitigate-log4shell.md
@@ -16,7 +16,7 @@ createdAt: "2025-11-18T07:36:13.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/mitigate-log4shell/mitigate-log4shell.yaml" target="-blank">/other-mpol/mitigate-log4shell/mitigate-log4shell.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: log4shell-mitigation

--- a/src/content/policies/other-mpol/mutate-large-termination-gps/mutate-large-termination-gps.md
+++ b/src/content/policies/other-mpol/mutate-large-termination-gps/mutate-large-termination-gps.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-14T18:23:14.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/mutate-large-termination-gps/mutate-large-termination-gps.yaml" target="-blank">/other-mpol/mutate-large-termination-gps/mutate-large-termination-gps.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: mutate-termination-grace-period-seconds

--- a/src/content/policies/other-mpol/prepend-image-registry/prepend-image-registry.md
+++ b/src/content/policies/other-mpol/prepend-image-registry/prepend-image-registry.md
@@ -16,7 +16,7 @@ createdAt: "2025-11-14T18:23:14.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/prepend-image-registry/prepend-image-registry.yaml" target="-blank">/other-mpol/prepend-image-registry/prepend-image-registry.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: prepend-registry

--- a/src/content/policies/other-mpol/remove-hostpath-volumes/remove-hostpath-volumes.md
+++ b/src/content/policies/other-mpol/remove-hostpath-volumes/remove-hostpath-volumes.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-18T07:36:13.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/remove-hostpath-volumes/remove-hostpath-volumes.yaml" target="-blank">/other-mpol/remove-hostpath-volumes/remove-hostpath-volumes.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: remove-hostpath-volumes

--- a/src/content/policies/other-mpol/replace-image-registry/replace-image-registry.md
+++ b/src/content/policies/other-mpol/replace-image-registry/replace-image-registry.md
@@ -16,7 +16,7 @@ createdAt: "2025-11-18T07:36:13.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/replace-image-registry/replace-image-registry.yaml" target="-blank">/other-mpol/replace-image-registry/replace-image-registry.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: replace-image-registry

--- a/src/content/policies/other-mpol/replace-ingress-hosts/replace-ingress-hosts.md
+++ b/src/content/policies/other-mpol/replace-ingress-hosts/replace-ingress-hosts.md
@@ -15,7 +15,7 @@ createdAt: "2025-11-18T07:36:13.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/replace-ingress-hosts/replace-ingress-hosts.yaml" target="-blank">/other-mpol/replace-ingress-hosts/replace-ingress-hosts.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: replace-ingress-hosts

--- a/src/content/policies/other-mpol/resolve-image-to-digest/resolve-image-to-digest.md
+++ b/src/content/policies/other-mpol/resolve-image-to-digest/resolve-image-to-digest.md
@@ -15,7 +15,7 @@ createdAt: "2025-11-18T07:36:13.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/resolve-image-to-digest/resolve-image-to-digest.yaml" target="-blank">/other-mpol/resolve-image-to-digest/resolve-image-to-digest.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: resolve-image-to-digest

--- a/src/content/policies/other-mpol/spread-pods-across-topology/spread-pods-across-topology.md
+++ b/src/content/policies/other-mpol/spread-pods-across-topology/spread-pods-across-topology.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-18T07:36:13.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/spread-pods-across-topology/spread-pods-across-topology.yaml" target="-blank">/other-mpol/spread-pods-across-topology/spread-pods-across-topology.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: spread-pods

--- a/src/content/policies/other-mpol/update-image-tag/update-image-tag.md
+++ b/src/content/policies/other-mpol/update-image-tag/update-image-tag.md
@@ -16,7 +16,7 @@ createdAt: "2025-11-18T07:36:13.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-mpol/update-image-tag/update-image-tag.yaml" target="-blank">/other-mpol/update-image-tag/update-image-tag.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: update-image-tag

--- a/src/content/policies/other-vpol/advanced-restrict-image-registries/advanced-restrict-image-registries.md
+++ b/src/content/policies/other-vpol/advanced-restrict-image-registries/advanced-restrict-image-registries.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/advanced-restrict-image-registries/advanced-restrict-image-registries.yaml" target="-blank">/other-vpol/advanced-restrict-image-registries/advanced-restrict-image-registries.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: advanced-restrict-image-registries

--- a/src/content/policies/other-vpol/allowed-annotations/allowed-annotations.md
+++ b/src/content/policies/other-vpol/allowed-annotations/allowed-annotations.md
@@ -18,7 +18,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/allowed-annotations/allowed-annotations.yaml" target="-blank">/other-vpol/allowed-annotations/allowed-annotations.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-annotations

--- a/src/content/policies/other-vpol/allowed-base-images/allowed-base-images.md
+++ b/src/content/policies/other-vpol/allowed-base-images/allowed-base-images.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-25T07:18:35.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/allowed-base-images/allowed-base-images.yaml" target="-blank">/other-vpol/allowed-base-images/allowed-base-images.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-base-images

--- a/src/content/policies/other-vpol/allowed-image-repos/allowed-image-repos.md
+++ b/src/content/policies/other-vpol/allowed-image-repos/allowed-image-repos.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-25T07:18:35.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/allowed-image-repos/allowed-image-repos.yaml" target="-blank">/other-vpol/allowed-image-repos/allowed-image-repos.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-image-repos

--- a/src/content/policies/other-vpol/allowed-pod-priorities/allowed-pod-priorities.md
+++ b/src/content/policies/other-vpol/allowed-pod-priorities/allowed-pod-priorities.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/allowed-pod-priorities/allowed-pod-priorities.yaml" target="-blank">/other-vpol/allowed-pod-priorities/allowed-pod-priorities.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-podpriorities

--- a/src/content/policies/other-vpol/block-cluster-admin-from-ns/block-cluster-admin-from-ns.md
+++ b/src/content/policies/other-vpol/block-cluster-admin-from-ns/block-cluster-admin-from-ns.md
@@ -19,7 +19,7 @@ createdAt: "2025-11-27T16:20:28.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/block-cluster-admin-from-ns/block-cluster-admin-from-ns.yaml" target="-blank">/other-vpol/block-cluster-admin-from-ns/block-cluster-admin-from-ns.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-cluster-admin-from-ns

--- a/src/content/policies/other-vpol/block-ephemeral-containers/block-ephemeral-containers.md
+++ b/src/content/policies/other-vpol/block-ephemeral-containers/block-ephemeral-containers.md
@@ -13,7 +13,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/block-ephemeral-containers/block-ephemeral-containers.yaml" target="-blank">/other-vpol/block-ephemeral-containers/block-ephemeral-containers.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-ephemeral-containers

--- a/src/content/policies/other-vpol/block-images-with-volumes/block-images-with-volumes.md
+++ b/src/content/policies/other-vpol/block-images-with-volumes/block-images-with-volumes.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-27T19:01:41.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/block-images-with-volumes/block-images-with-volumes.yaml" target="-blank">/other-vpol/block-images-with-volumes/block-images-with-volumes.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-images-with-volumes

--- a/src/content/policies/other-vpol/block-kubectl-cp/block-kubectl-cp.md
+++ b/src/content/policies/other-vpol/block-kubectl-cp/block-kubectl-cp.md
@@ -17,7 +17,7 @@ createdAt: "2025-12-02T17:45:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/block-kubectl-cp/block-kubectl-cp.yaml" target="-blank">/other-vpol/block-kubectl-cp/block-kubectl-cp.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-kubectl-cp

--- a/src/content/policies/other-vpol/block-large-images/block-large-images.md
+++ b/src/content/policies/other-vpol/block-large-images/block-large-images.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-27T19:01:41.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/block-large-images/block-large-images.yaml" target="-blank">/other-vpol/block-large-images/block-large-images.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-large-images

--- a/src/content/policies/other-vpol/block-pod-exec-by-namespace-label/block-pod-exec-by-namespace-label.md
+++ b/src/content/policies/other-vpol/block-pod-exec-by-namespace-label/block-pod-exec-by-namespace-label.md
@@ -17,7 +17,7 @@ createdAt: "2025-12-11T12:49:35.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/block-pod-exec-by-namespace-label/block-pod-exec-by-namespace-label.yaml" target="-blank">/other-vpol/block-pod-exec-by-namespace-label/block-pod-exec-by-namespace-label.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-namespace-label

--- a/src/content/policies/other-vpol/block-pod-exec-by-namespace/block-pod-exec-by-namespace.md
+++ b/src/content/policies/other-vpol/block-pod-exec-by-namespace/block-pod-exec-by-namespace.md
@@ -17,7 +17,7 @@ createdAt: "2025-12-02T17:45:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/block-pod-exec-by-namespace/block-pod-exec-by-namespace.yaml" target="-blank">/other-vpol/block-pod-exec-by-namespace/block-pod-exec-by-namespace.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-namespace-name

--- a/src/content/policies/other-vpol/block-pod-exec-by-pod-and-container/block-pod-exec-by-pod-and-container.md
+++ b/src/content/policies/other-vpol/block-pod-exec-by-pod-and-container/block-pod-exec-by-pod-and-container.md
@@ -17,7 +17,7 @@ createdAt: "2025-12-11T12:49:35.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/block-pod-exec-by-pod-and-container/block-pod-exec-by-pod-and-container.yaml" target="-blank">/other-vpol/block-pod-exec-by-pod-and-container/block-pod-exec-by-pod-and-container.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-pod-and-container

--- a/src/content/policies/other-vpol/block-pod-exec-by-pod-label/block-pod-exec-by-pod-label.md
+++ b/src/content/policies/other-vpol/block-pod-exec-by-pod-label/block-pod-exec-by-pod-label.md
@@ -17,7 +17,7 @@ createdAt: "2025-12-02T17:45:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/block-pod-exec-by-pod-label/block-pod-exec-by-pod-label.yaml" target="-blank">/other-vpol/block-pod-exec-by-pod-label/block-pod-exec-by-pod-label.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-pod-label

--- a/src/content/policies/other-vpol/block-pod-exec-by-pod-name/block-pod-exec-by-pod-name.md
+++ b/src/content/policies/other-vpol/block-pod-exec-by-pod-name/block-pod-exec-by-pod-name.md
@@ -17,7 +17,7 @@ createdAt: "2025-12-02T17:45:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/block-pod-exec-by-pod-name/block-pod-exec-by-pod-name.yaml" target="-blank">/other-vpol/block-pod-exec-by-pod-name/block-pod-exec-by-pod-name.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-pod-name

--- a/src/content/policies/other-vpol/block-updates-deletes/block-updates-deletes.md
+++ b/src/content/policies/other-vpol/block-updates-deletes/block-updates-deletes.md
@@ -16,7 +16,7 @@ createdAt: "2025-12-11T12:49:35.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/block-updates-deletes/block-updates-deletes.yaml" target="-blank">/other-vpol/block-updates-deletes/block-updates-deletes.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-updates-deletes

--- a/src/content/policies/other-vpol/check-env-vars/check-env-vars.md
+++ b/src/content/policies/other-vpol/check-env-vars/check-env-vars.md
@@ -16,7 +16,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/check-env-vars/check-env-vars.yaml" target="-blank">/other-vpol/check-env-vars/check-env-vars.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-env-vars

--- a/src/content/policies/other-vpol/check-hpa-exists/check-hpa-exists.md
+++ b/src/content/policies/other-vpol/check-hpa-exists/check-hpa-exists.md
@@ -19,7 +19,7 @@ createdAt: "2025-12-15T09:53:18.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/check-hpa-exists/check-hpa-exists.yaml" target="-blank">/other-vpol/check-hpa-exists/check-hpa-exists.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-hpa-exists

--- a/src/content/policies/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/check-ingress-nginx-controller-version-and-annotation-policy.md
+++ b/src/content/policies/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/check-ingress-nginx-controller-version-and-annotation-policy.md
@@ -18,7 +18,7 @@ createdAt: "2025-12-15T09:53:18.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/check-ingress-nginx-controller-version-and-annotation-policy.yaml" target="-blank">/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/check-ingress-nginx-controller-version-and-annotation-policy.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-ingress-nginx-controller-version-and-annotation-policy

--- a/src/content/policies/other-vpol/check-node-for-cve-2022-0185/check-node-for-cve-2022-0185.md
+++ b/src/content/policies/other-vpol/check-node-for-cve-2022-0185/check-node-for-cve-2022-0185.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/check-node-for-cve-2022-0185/check-node-for-cve-2022-0185.yaml" target="-blank">/other-vpol/check-node-for-cve-2022-0185/check-node-for-cve-2022-0185.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-kernel

--- a/src/content/policies/other-vpol/check-nvidia-gpu/check-nvidia-gpu.md
+++ b/src/content/policies/other-vpol/check-nvidia-gpu/check-nvidia-gpu.md
@@ -17,7 +17,7 @@ createdAt: "2025-12-16T13:58:08.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/check-nvidia-gpu/check-nvidia-gpu.yaml" target="-blank">/other-vpol/check-nvidia-gpu/check-nvidia-gpu.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-nvidia-gpus

--- a/src/content/policies/other-vpol/check-serviceaccount-secrets/check-serviceaccount-secrets.md
+++ b/src/content/policies/other-vpol/check-serviceaccount-secrets/check-serviceaccount-secrets.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/check-serviceaccount-secrets/check-serviceaccount-secrets.yaml" target="-blank">/other-vpol/check-serviceaccount-secrets/check-serviceaccount-secrets.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-serviceaccount-secrets

--- a/src/content/policies/other-vpol/check-serviceaccount/check-serviceaccount.md
+++ b/src/content/policies/other-vpol/check-serviceaccount/check-serviceaccount.md
@@ -18,7 +18,7 @@ createdAt: "2025-12-16T13:58:08.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/check-serviceaccount/check-serviceaccount.yaml" target="-blank">/other-vpol/check-serviceaccount/check-serviceaccount.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-sa

--- a/src/content/policies/other-vpol/check-subjectaccessreview/check-subjectaccessreview.md
+++ b/src/content/policies/other-vpol/check-subjectaccessreview/check-subjectaccessreview.md
@@ -17,7 +17,7 @@ createdAt: "2025-12-16T13:58:08.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/check-subjectaccessreview/check-subjectaccessreview.yaml" target="-blank">/other-vpol/check-subjectaccessreview/check-subjectaccessreview.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-subjectaccessreview

--- a/src/content/policies/other-vpol/deny-commands-in-exec-probe/deny-commands-in-exec-probe.md
+++ b/src/content/policies/other-vpol/deny-commands-in-exec-probe/deny-commands-in-exec-probe.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/deny-commands-in-exec-probe/deny-commands-in-exec-probe.yaml" target="-blank">/other-vpol/deny-commands-in-exec-probe/deny-commands-in-exec-probe.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-commands-in-exec-probe

--- a/src/content/policies/other-vpol/deny-secret-service-account-token-type/deny-secret-service-account-token-type.md
+++ b/src/content/policies/other-vpol/deny-secret-service-account-token-type/deny-secret-service-account-token-type.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/deny-secret-service-account-token-type/deny-secret-service-account-token-type.yaml" target="-blank">/other-vpol/deny-secret-service-account-token-type/deny-secret-service-account-token-type.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-secret-service-account-token-type

--- a/src/content/policies/other-vpol/disallow-all-secrets/disallow-all-secrets.md
+++ b/src/content/policies/other-vpol/disallow-all-secrets/disallow-all-secrets.md
@@ -18,7 +18,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/disallow-all-secrets/disallow-all-secrets.yaml" target="-blank">/other-vpol/disallow-all-secrets/disallow-all-secrets.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: no-secrets

--- a/src/content/policies/other-vpol/disallow-localhost-services/disallow-localhost-services.md
+++ b/src/content/policies/other-vpol/disallow-localhost-services/disallow-localhost-services.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/disallow-localhost-services/disallow-localhost-services.yaml" target="-blank">/other-vpol/disallow-localhost-services/disallow-localhost-services.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: no-localhost-service

--- a/src/content/policies/other-vpol/disallow-secrets-from-env-vars/disallow-secrets-from-env-vars.md
+++ b/src/content/policies/other-vpol/disallow-secrets-from-env-vars/disallow-secrets-from-env-vars.md
@@ -18,7 +18,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/disallow-secrets-from-env-vars/disallow-secrets-from-env-vars.yaml" target="-blank">/other-vpol/disallow-secrets-from-env-vars/disallow-secrets-from-env-vars.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: secrets-not-from-env-vars

--- a/src/content/policies/other-vpol/docker-socket-requires-label/docker-socket-requires-label.md
+++ b/src/content/policies/other-vpol/docker-socket-requires-label/docker-socket-requires-label.md
@@ -16,7 +16,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/docker-socket-requires-label/docker-socket-requires-label.yaml" target="-blank">/other-vpol/docker-socket-requires-label/docker-socket-requires-label.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: docker-socket-check

--- a/src/content/policies/other-vpol/enforce-pod-duration/enforce-pod-duration.md
+++ b/src/content/policies/other-vpol/enforce-pod-duration/enforce-pod-duration.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/enforce-pod-duration/enforce-pod-duration.yaml" target="-blank">/other-vpol/enforce-pod-duration/enforce-pod-duration.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: pod-lifetime

--- a/src/content/policies/other-vpol/enforce-readwriteonce-pod/enforce-readwriteonce-pod.md
+++ b/src/content/policies/other-vpol/enforce-readwriteonce-pod/enforce-readwriteonce-pod.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/enforce-readwriteonce-pod/enforce-readwriteonce-pod.yaml" target="-blank">/other-vpol/enforce-readwriteonce-pod/enforce-readwriteonce-pod.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: readwriteonce-pod

--- a/src/content/policies/other-vpol/ensure-probes-different/ensure-probes-different.md
+++ b/src/content/policies/other-vpol/ensure-probes-different/ensure-probes-different.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/ensure-probes-different/ensure-probes-different.yaml" target="-blank">/other-vpol/ensure-probes-different/ensure-probes-different.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: validate-probes

--- a/src/content/policies/other-vpol/ensure-readonly-hostpath/ensure-readonly-hostpath.md
+++ b/src/content/policies/other-vpol/ensure-readonly-hostpath/ensure-readonly-hostpath.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/ensure-readonly-hostpath/ensure-readonly-hostpath.yaml" target="-blank">/other-vpol/ensure-readonly-hostpath/ensure-readonly-hostpath.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: ensure-readonly-hostpath

--- a/src/content/policies/other-vpol/exclude-namespaces-dynamically/exclude-namespaces-dynamically.md
+++ b/src/content/policies/other-vpol/exclude-namespaces-dynamically/exclude-namespaces-dynamically.md
@@ -18,7 +18,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/exclude-namespaces-dynamically/exclude-namespaces-dynamically.yaml" target="-blank">/other-vpol/exclude-namespaces-dynamically/exclude-namespaces-dynamically.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: exclude-namespaces-example

--- a/src/content/policies/other-vpol/forbid-cpu-limits/forbid-cpu-limits.md
+++ b/src/content/policies/other-vpol/forbid-cpu-limits/forbid-cpu-limits.md
@@ -16,7 +16,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/forbid-cpu-limits/forbid-cpu-limits.yaml" target="-blank">/other-vpol/forbid-cpu-limits/forbid-cpu-limits.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: forbid-cpu-limits

--- a/src/content/policies/other-vpol/imagepullpolicy-always/imagepullpolicy-always.md
+++ b/src/content/policies/other-vpol/imagepullpolicy-always/imagepullpolicy-always.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/imagepullpolicy-always/imagepullpolicy-always.yaml" target="-blank">/other-vpol/imagepullpolicy-always/imagepullpolicy-always.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: imagepullpolicy-always

--- a/src/content/policies/other-vpol/ingress-host-match-tls/ingress-host-match-tls.md
+++ b/src/content/policies/other-vpol/ingress-host-match-tls/ingress-host-match-tls.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/ingress-host-match-tls/ingress-host-match-tls.yaml" target="-blank">/other-vpol/ingress-host-match-tls/ingress-host-match-tls.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: ingress-host-match-tls

--- a/src/content/policies/other-vpol/limit-containers-per-pod/limit-containers-per-pod.md
+++ b/src/content/policies/other-vpol/limit-containers-per-pod/limit-containers-per-pod.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/limit-containers-per-pod/limit-containers-per-pod.yaml" target="-blank">/other-vpol/limit-containers-per-pod/limit-containers-per-pod.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: limit-containers-per-pod

--- a/src/content/policies/other-vpol/limit-hostpath-type-pv/limit-hostpath-type-pv.md
+++ b/src/content/policies/other-vpol/limit-hostpath-type-pv/limit-hostpath-type-pv.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/limit-hostpath-type-pv/limit-hostpath-type-pv.yaml" target="-blank">/other-vpol/limit-hostpath-type-pv/limit-hostpath-type-pv.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: limit-hostpath-type-pv

--- a/src/content/policies/other-vpol/limit-hostpath-vols/limit-hostpath-vols.md
+++ b/src/content/policies/other-vpol/limit-hostpath-vols/limit-hostpath-vols.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/limit-hostpath-vols/limit-hostpath-vols.yaml" target="-blank">/other-vpol/limit-hostpath-vols/limit-hostpath-vols.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: limit-hostpath-vols

--- a/src/content/policies/other-vpol/memory-requests-equal-limits/memory-requests-equal-limits.md
+++ b/src/content/policies/other-vpol/memory-requests-equal-limits/memory-requests-equal-limits.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/memory-requests-equal-limits/memory-requests-equal-limits.yaml" target="-blank">/other-vpol/memory-requests-equal-limits/memory-requests-equal-limits.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: memory-requests-equal-limits

--- a/src/content/policies/other-vpol/metadata-match-regex/metadata-match-regex.md
+++ b/src/content/policies/other-vpol/metadata-match-regex/metadata-match-regex.md
@@ -18,7 +18,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/metadata-match-regex/metadata-match-regex.yaml" target="-blank">/other-vpol/metadata-match-regex/metadata-match-regex.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: metadata-match-regex

--- a/src/content/policies/other-vpol/pdb-maxunavailable/pdb-maxunavailable.md
+++ b/src/content/policies/other-vpol/pdb-maxunavailable/pdb-maxunavailable.md
@@ -16,7 +16,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/pdb-maxunavailable/pdb-maxunavailable.yaml" target="-blank">/other-vpol/pdb-maxunavailable/pdb-maxunavailable.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: pdb-maxunavailable

--- a/src/content/policies/other-vpol/prevent-bare-pods/prevent-bare-pods.md
+++ b/src/content/policies/other-vpol/prevent-bare-pods/prevent-bare-pods.md
@@ -18,7 +18,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/prevent-bare-pods/prevent-bare-pods.yaml" target="-blank">/other-vpol/prevent-bare-pods/prevent-bare-pods.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: prevent-bare-pods

--- a/src/content/policies/other-vpol/prevent-cr8escape/prevent-cr8escape.md
+++ b/src/content/policies/other-vpol/prevent-cr8escape/prevent-cr8escape.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/prevent-cr8escape/prevent-cr8escape.yaml" target="-blank">/other-vpol/prevent-cr8escape/prevent-cr8escape.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: prevent-cr8escape

--- a/src/content/policies/other-vpol/require-annotations/require-annotations.md
+++ b/src/content/policies/other-vpol/require-annotations/require-annotations.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/require-annotations/require-annotations.yaml" target="-blank">/other-vpol/require-annotations/require-annotations.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-annotations

--- a/src/content/policies/other-vpol/require-container-port-names/require-container-port-names.md
+++ b/src/content/policies/other-vpol/require-container-port-names/require-container-port-names.md
@@ -16,7 +16,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/require-container-port-names/require-container-port-names.yaml" target="-blank">/other-vpol/require-container-port-names/require-container-port-names.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-container-port-names

--- a/src/content/policies/other-vpol/require-deployments-have-multiple-replicas/require-deployments-have-multiple-replicas.md
+++ b/src/content/policies/other-vpol/require-deployments-have-multiple-replicas/require-deployments-have-multiple-replicas.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/require-deployments-have-multiple-replicas/require-deployments-have-multiple-replicas.yaml" target="-blank">/other-vpol/require-deployments-have-multiple-replicas/require-deployments-have-multiple-replicas.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deployment-has-multiple-replicas

--- a/src/content/policies/other-vpol/require-emptydir-requests-limits/require-emptydir-requests-limits.md
+++ b/src/content/policies/other-vpol/require-emptydir-requests-limits/require-emptydir-requests-limits.md
@@ -16,7 +16,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/require-emptydir-requests-limits/require-emptydir-requests-limits.yaml" target="-blank">/other-vpol/require-emptydir-requests-limits/require-emptydir-requests-limits.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-emptydir-requests-and-limits

--- a/src/content/policies/other-vpol/require-image-checksum/require-image-checksum.md
+++ b/src/content/policies/other-vpol/require-image-checksum/require-image-checksum.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/require-image-checksum/require-image-checksum.yaml" target="-blank">/other-vpol/require-image-checksum/require-image-checksum.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-image-checksum

--- a/src/content/policies/other-vpol/require-ingress-https/require-ingress-https.md
+++ b/src/content/policies/other-vpol/require-ingress-https/require-ingress-https.md
@@ -16,7 +16,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/require-ingress-https/require-ingress-https.yaml" target="-blank">/other-vpol/require-ingress-https/require-ingress-https.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-ingress-https

--- a/src/content/policies/other-vpol/require-non-root-groups/require-non-root-groups.md
+++ b/src/content/policies/other-vpol/require-non-root-groups/require-non-root-groups.md
@@ -18,7 +18,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/require-non-root-groups/require-non-root-groups.yaml" target="-blank">/other-vpol/require-non-root-groups/require-non-root-groups.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-non-root-groups

--- a/src/content/policies/other-vpol/require-pod-priorityclassname/require-pod-priorityclassname.md
+++ b/src/content/policies/other-vpol/require-pod-priorityclassname/require-pod-priorityclassname.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/require-pod-priorityclassname/require-pod-priorityclassname.yaml" target="-blank">/other-vpol/require-pod-priorityclassname/require-pod-priorityclassname.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-pod-priorityclassname

--- a/src/content/policies/other-vpol/require-qos-burstable/require-qos-burstable.md
+++ b/src/content/policies/other-vpol/require-qos-burstable/require-qos-burstable.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/require-qos-burstable/require-qos-burstable.yaml" target="-blank">/other-vpol/require-qos-burstable/require-qos-burstable.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-qos-burstable

--- a/src/content/policies/other-vpol/require-qos-guaranteed/require-qos-guaranteed.md
+++ b/src/content/policies/other-vpol/require-qos-guaranteed/require-qos-guaranteed.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/require-qos-guaranteed/require-qos-guaranteed.yaml" target="-blank">/other-vpol/require-qos-guaranteed/require-qos-guaranteed.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-qos-guaranteed

--- a/src/content/policies/other-vpol/require-storageclass/require-storageclass.md
+++ b/src/content/policies/other-vpol/require-storageclass/require-storageclass.md
@@ -18,7 +18,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/require-storageclass/require-storageclass.yaml" target="-blank">/other-vpol/require-storageclass/require-storageclass.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-storageclass

--- a/src/content/policies/other-vpol/restrict-annotations/restrict-annotations.md
+++ b/src/content/policies/other-vpol/restrict-annotations/restrict-annotations.md
@@ -18,7 +18,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-annotations/restrict-annotations.yaml" target="-blank">/other-vpol/restrict-annotations/restrict-annotations.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-annotations

--- a/src/content/policies/other-vpol/restrict-binding-clusteradmin/restrict-binding-clusteradmin.md
+++ b/src/content/policies/other-vpol/restrict-binding-clusteradmin/restrict-binding-clusteradmin.md
@@ -19,7 +19,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-binding-clusteradmin/restrict-binding-clusteradmin.yaml" target="-blank">/other-vpol/restrict-binding-clusteradmin/restrict-binding-clusteradmin.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-binding-clusteradmin

--- a/src/content/policies/other-vpol/restrict-binding-system-groups/restrict-binding-system-groups.md
+++ b/src/content/policies/other-vpol/restrict-binding-system-groups/restrict-binding-system-groups.md
@@ -20,7 +20,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-binding-system-groups/restrict-binding-system-groups.yaml" target="-blank">/other-vpol/restrict-binding-system-groups/restrict-binding-system-groups.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-binding-system-groups

--- a/src/content/policies/other-vpol/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.md
+++ b/src/content/policies/other-vpol/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.md
@@ -18,7 +18,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml" target="-blank">/other-vpol/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-clusterrole-nodesproxy

--- a/src/content/policies/other-vpol/restrict-controlplane-scheduling/restrict-controlplane-scheduling.md
+++ b/src/content/policies/other-vpol/restrict-controlplane-scheduling/restrict-controlplane-scheduling.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-controlplane-scheduling/restrict-controlplane-scheduling.yaml" target="-blank">/other-vpol/restrict-controlplane-scheduling/restrict-controlplane-scheduling.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-controlplane-scheduling

--- a/src/content/policies/other-vpol/restrict-deprecated-registry/restrict-deprecated-registry.md
+++ b/src/content/policies/other-vpol/restrict-deprecated-registry/restrict-deprecated-registry.md
@@ -18,7 +18,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-deprecated-registry/restrict-deprecated-registry.yaml" target="-blank">/other-vpol/restrict-deprecated-registry/restrict-deprecated-registry.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-deprecated-registry

--- a/src/content/policies/other-vpol/restrict-edit-for-endpoints/restrict-edit-for-endpoints.md
+++ b/src/content/policies/other-vpol/restrict-edit-for-endpoints/restrict-edit-for-endpoints.md
@@ -16,7 +16,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-edit-for-endpoints/restrict-edit-for-endpoints.yaml" target="-blank">/other-vpol/restrict-edit-for-endpoints/restrict-edit-for-endpoints.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-edit-for-endpoints

--- a/src/content/policies/other-vpol/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.md
+++ b/src/content/policies/other-vpol/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.md
@@ -19,7 +19,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.yaml" target="-blank">/other-vpol/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-escalation-verbs-roles

--- a/src/content/policies/other-vpol/restrict-ingress-classes/restrict-ingress-classes.md
+++ b/src/content/policies/other-vpol/restrict-ingress-classes/restrict-ingress-classes.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-ingress-classes/restrict-ingress-classes.yaml" target="-blank">/other-vpol/restrict-ingress-classes/restrict-ingress-classes.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-ingress-classes

--- a/src/content/policies/other-vpol/restrict-ingress-defaultbackend/restrict-ingress-defaultbackend.md
+++ b/src/content/policies/other-vpol/restrict-ingress-defaultbackend/restrict-ingress-defaultbackend.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-ingress-defaultbackend/restrict-ingress-defaultbackend.yaml" target="-blank">/other-vpol/restrict-ingress-defaultbackend/restrict-ingress-defaultbackend.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-ingress-defaultbackend

--- a/src/content/policies/other-vpol/restrict-ingress-wildcard/restrict-ingress-wildcard.md
+++ b/src/content/policies/other-vpol/restrict-ingress-wildcard/restrict-ingress-wildcard.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-ingress-wildcard/restrict-ingress-wildcard.yaml" target="-blank">/other-vpol/restrict-ingress-wildcard/restrict-ingress-wildcard.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-ingress-wildcard

--- a/src/content/policies/other-vpol/restrict-jobs/restrict-jobs.md
+++ b/src/content/policies/other-vpol/restrict-jobs/restrict-jobs.md
@@ -16,7 +16,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-jobs/restrict-jobs.yaml" target="-blank">/other-vpol/restrict-jobs/restrict-jobs.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-jobs

--- a/src/content/policies/other-vpol/restrict-loadbalancer/restrict-loadbalancer.md
+++ b/src/content/policies/other-vpol/restrict-loadbalancer/restrict-loadbalancer.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-loadbalancer/restrict-loadbalancer.yaml" target="-blank">/other-vpol/restrict-loadbalancer/restrict-loadbalancer.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: no-loadbalancer-service

--- a/src/content/policies/other-vpol/restrict-networkpolicy-empty-podselector/restrict-networkpolicy-empty-podselector.md
+++ b/src/content/policies/other-vpol/restrict-networkpolicy-empty-podselector/restrict-networkpolicy-empty-podselector.md
@@ -18,7 +18,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-networkpolicy-empty-podselector/restrict-networkpolicy-empty-podselector.yaml" target="-blank">/other-vpol/restrict-networkpolicy-empty-podselector/restrict-networkpolicy-empty-podselector.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-networkpolicy-empty-podselector

--- a/src/content/policies/other-vpol/restrict-node-affinity/restrict-node-affinity.md
+++ b/src/content/policies/other-vpol/restrict-node-affinity/restrict-node-affinity.md
@@ -16,7 +16,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-node-affinity/restrict-node-affinity.yaml" target="-blank">/other-vpol/restrict-node-affinity/restrict-node-affinity.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-node-affinity

--- a/src/content/policies/other-vpol/restrict-node-label-creation/restrict-node-label-creation.md
+++ b/src/content/policies/other-vpol/restrict-node-label-creation/restrict-node-label-creation.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-node-label-creation/restrict-node-label-creation.yaml" target="-blank">/other-vpol/restrict-node-label-creation/restrict-node-label-creation.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-node-label-creation

--- a/src/content/policies/other-vpol/restrict-pod-controller-serviceaccount-updates/restrict-pod-controller-serviceaccount-updates.md
+++ b/src/content/policies/other-vpol/restrict-pod-controller-serviceaccount-updates/restrict-pod-controller-serviceaccount-updates.md
@@ -16,7 +16,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-pod-controller-serviceaccount-updates/restrict-pod-controller-serviceaccount-updates.yaml" target="-blank">/other-vpol/restrict-pod-controller-serviceaccount-updates/restrict-pod-controller-serviceaccount-updates.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-pod-controller-serviceaccount-updates

--- a/src/content/policies/other-vpol/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.md
+++ b/src/content/policies/other-vpol/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml" target="-blank">/other-vpol/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-sa-automount-sa-token

--- a/src/content/policies/other-vpol/restrict-secret-role-verbs/restrict-secret-role-verbs.md
+++ b/src/content/policies/other-vpol/restrict-secret-role-verbs/restrict-secret-role-verbs.md
@@ -19,7 +19,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-secret-role-verbs/restrict-secret-role-verbs.yaml" target="-blank">/other-vpol/restrict-secret-role-verbs/restrict-secret-role-verbs.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-secret-role-verbs

--- a/src/content/policies/other-vpol/restrict-secrets-by-name/restrict-secrets-by-name.md
+++ b/src/content/policies/other-vpol/restrict-secrets-by-name/restrict-secrets-by-name.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-secrets-by-name/restrict-secrets-by-name.yaml" target="-blank">/other-vpol/restrict-secrets-by-name/restrict-secrets-by-name.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-secrets-by-name

--- a/src/content/policies/other-vpol/restrict-service-port-range/restrict-service-port-range.md
+++ b/src/content/policies/other-vpol/restrict-service-port-range/restrict-service-port-range.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-service-port-range/restrict-service-port-range.yaml" target="-blank">/other-vpol/restrict-service-port-range/restrict-service-port-range.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-service-port-range

--- a/src/content/policies/other-vpol/restrict-storageclass/restrict-storageclass.md
+++ b/src/content/policies/other-vpol/restrict-storageclass/restrict-storageclass.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-storageclass/restrict-storageclass.yaml" target="-blank">/other-vpol/restrict-storageclass/restrict-storageclass.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-storageclass

--- a/src/content/policies/other-vpol/restrict-usergroup-fsgroup-id/restrict-usergroup-fsgroup-id.md
+++ b/src/content/policies/other-vpol/restrict-usergroup-fsgroup-id/restrict-usergroup-fsgroup-id.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-usergroup-fsgroup-id/restrict-usergroup-fsgroup-id.yaml" target="-blank">/other-vpol/restrict-usergroup-fsgroup-id/restrict-usergroup-fsgroup-id.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: validate-userid-groupid-fsgroup

--- a/src/content/policies/other-vpol/restrict-wildcard-resources/restrict-wildcard-resources.md
+++ b/src/content/policies/other-vpol/restrict-wildcard-resources/restrict-wildcard-resources.md
@@ -20,7 +20,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-wildcard-resources/restrict-wildcard-resources.yaml" target="-blank">/other-vpol/restrict-wildcard-resources/restrict-wildcard-resources.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-wildcard-resources

--- a/src/content/policies/other-vpol/restrict-wildcard-verbs/restrict-wildcard-verbs.md
+++ b/src/content/policies/other-vpol/restrict-wildcard-verbs/restrict-wildcard-verbs.md
@@ -20,7 +20,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml" target="-blank">/other-vpol/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-wildcard-verbs

--- a/src/content/policies/other-vpol/topologyspreadconstraints-policy/topologyspreadconstraints-policy.md
+++ b/src/content/policies/other-vpol/topologyspreadconstraints-policy/topologyspreadconstraints-policy.md
@@ -18,7 +18,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/topologyspreadconstraints-policy/topologyspreadconstraints-policy.yaml" target="-blank">/other-vpol/topologyspreadconstraints-policy/topologyspreadconstraints-policy.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: topologyspreadconstraints-policy

--- a/src/content/policies/other-vpol/unique-ingress-paths/unique-ingress-paths.md
+++ b/src/content/policies/other-vpol/unique-ingress-paths/unique-ingress-paths.md
@@ -17,7 +17,7 @@ createdAt: "2025-09-04T05:15:25.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other-vpol/unique-ingress-paths/unique-ingress-paths.yaml" target="-blank">/other-vpol/unique-ingress-paths/unique-ingress-paths.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: unique-ingress-path

--- a/src/content/policies/other/verify-image-ivpol/verify-image-ivpol.md
+++ b/src/content/policies/other/verify-image-ivpol/verify-image-ivpol.md
@@ -18,7 +18,7 @@ createdAt: "2025-03-27T21:20:10.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/other/verify-image-ivpol/verify-image-ivpol.yaml" target="-blank">/other/verify-image-ivpol/verify-image-ivpol.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ImageValidatingPolicy
 metadata:
   name: verify-image-ivpol

--- a/src/content/policies/pod-security-vpol/baseline/disallow-capabilities/disallow-capabilities.md
+++ b/src/content/policies/pod-security-vpol/baseline/disallow-capabilities/disallow-capabilities.md
@@ -17,7 +17,7 @@ createdAt: "2025-06-26T07:48:12.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/pod-security-vpol/baseline/disallow-capabilities/disallow-capabilities.yaml" target="-blank">/pod-security-vpol/baseline/disallow-capabilities/disallow-capabilities.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-capabilities

--- a/src/content/policies/pod-security-vpol/baseline/disallow-host-namespaces/disallow-host-namespaces.md
+++ b/src/content/policies/pod-security-vpol/baseline/disallow-host-namespaces/disallow-host-namespaces.md
@@ -17,7 +17,7 @@ createdAt: "2025-06-26T07:48:12.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/pod-security-vpol/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml" target="-blank">/pod-security-vpol/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-namespaces

--- a/src/content/policies/pod-security-vpol/baseline/disallow-host-path/disallow-host-path.md
+++ b/src/content/policies/pod-security-vpol/baseline/disallow-host-path/disallow-host-path.md
@@ -18,7 +18,7 @@ createdAt: "2025-06-26T07:48:12.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/pod-security-vpol/baseline/disallow-host-path/disallow-host-path.yaml" target="-blank">/pod-security-vpol/baseline/disallow-host-path/disallow-host-path.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-path

--- a/src/content/policies/pod-security-vpol/baseline/disallow-host-ports/disallow-host-ports.md
+++ b/src/content/policies/pod-security-vpol/baseline/disallow-host-ports/disallow-host-ports.md
@@ -17,7 +17,7 @@ createdAt: "2025-06-26T07:48:12.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/pod-security-vpol/baseline/disallow-host-ports/disallow-host-ports.yaml" target="-blank">/pod-security-vpol/baseline/disallow-host-ports/disallow-host-ports.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-ports

--- a/src/content/policies/pod-security-vpol/baseline/disallow-host-process/disallow-host-process.md
+++ b/src/content/policies/pod-security-vpol/baseline/disallow-host-process/disallow-host-process.md
@@ -17,7 +17,7 @@ createdAt: "2025-06-26T07:48:12.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/pod-security-vpol/baseline/disallow-host-process/disallow-host-process.yaml" target="-blank">/pod-security-vpol/baseline/disallow-host-process/disallow-host-process.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-process

--- a/src/content/policies/pod-security-vpol/baseline/disallow-privileged-containers/disallow-privileged-containers.md
+++ b/src/content/policies/pod-security-vpol/baseline/disallow-privileged-containers/disallow-privileged-containers.md
@@ -17,7 +17,7 @@ createdAt: "2025-06-26T07:48:12.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/pod-security-vpol/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml" target="-blank">/pod-security-vpol/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-privileged-containers

--- a/src/content/policies/pod-security-vpol/baseline/disallow-proc-mount/disallow-proc-mount.md
+++ b/src/content/policies/pod-security-vpol/baseline/disallow-proc-mount/disallow-proc-mount.md
@@ -17,7 +17,7 @@ createdAt: "2025-06-26T07:48:12.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/pod-security-vpol/baseline/disallow-proc-mount/disallow-proc-mount.yaml" target="-blank">/pod-security-vpol/baseline/disallow-proc-mount/disallow-proc-mount.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-proc-mount

--- a/src/content/policies/pod-security-vpol/baseline/disallow-selinux/disallow-selinux.md
+++ b/src/content/policies/pod-security-vpol/baseline/disallow-selinux/disallow-selinux.md
@@ -17,7 +17,7 @@ createdAt: "2025-06-26T07:48:12.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/pod-security-vpol/baseline/disallow-selinux/disallow-selinux.yaml" target="-blank">/pod-security-vpol/baseline/disallow-selinux/disallow-selinux.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-selinux

--- a/src/content/policies/pod-security-vpol/baseline/restrict-seccomp/restrict-seccomp.md
+++ b/src/content/policies/pod-security-vpol/baseline/restrict-seccomp/restrict-seccomp.md
@@ -17,7 +17,7 @@ createdAt: "2025-06-26T07:48:12.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/pod-security-vpol/baseline/restrict-seccomp/restrict-seccomp.yaml" target="-blank">/pod-security-vpol/baseline/restrict-seccomp/restrict-seccomp.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-seccomp

--- a/src/content/policies/pod-security-vpol/baseline/restrict-sysctls/restrict-sysctls.md
+++ b/src/content/policies/pod-security-vpol/baseline/restrict-sysctls/restrict-sysctls.md
@@ -17,7 +17,7 @@ createdAt: "2025-06-26T07:48:12.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/pod-security-vpol/baseline/restrict-sysctls/restrict-sysctls.yaml" target="-blank">/pod-security-vpol/baseline/restrict-sysctls/restrict-sysctls.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-sysctls

--- a/src/content/policies/pod-security-vpol/restricted/disallow-capabilities-strict/disallow-capabilities-strict.md
+++ b/src/content/policies/pod-security-vpol/restricted/disallow-capabilities-strict/disallow-capabilities-strict.md
@@ -17,7 +17,7 @@ createdAt: "2025-06-26T07:48:12.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/pod-security-vpol/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml" target="-blank">/pod-security-vpol/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-capabilities-strict

--- a/src/content/policies/pod-security-vpol/restricted/disallow-privilege-escalation/disallow-privilege-escalation.md
+++ b/src/content/policies/pod-security-vpol/restricted/disallow-privilege-escalation/disallow-privilege-escalation.md
@@ -17,7 +17,7 @@ createdAt: "2025-06-26T07:48:12.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/pod-security-vpol/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml" target="-blank">/pod-security-vpol/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-privilege-escalation

--- a/src/content/policies/pod-security-vpol/restricted/require-run-as-non-root-user/require-run-as-non-root-user.md
+++ b/src/content/policies/pod-security-vpol/restricted/require-run-as-non-root-user/require-run-as-non-root-user.md
@@ -17,7 +17,7 @@ createdAt: "2025-06-26T07:48:12.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/pod-security-vpol/restricted/require-run-as-non-root-user/require-run-as-non-root-user.yaml" target="-blank">/pod-security-vpol/restricted/require-run-as-non-root-user/require-run-as-non-root-user.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-run-as-non-root-user

--- a/src/content/policies/pod-security-vpol/restricted/require-run-as-nonroot/require-run-as-nonroot.md
+++ b/src/content/policies/pod-security-vpol/restricted/require-run-as-nonroot/require-run-as-nonroot.md
@@ -17,7 +17,7 @@ createdAt: "2025-06-26T07:48:12.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/pod-security-vpol/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml" target="-blank">/pod-security-vpol/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-run-as-nonroot

--- a/src/content/policies/pod-security-vpol/restricted/restrict-seccomp-strict/restrict-seccomp-strict.md
+++ b/src/content/policies/pod-security-vpol/restricted/restrict-seccomp-strict/restrict-seccomp-strict.md
@@ -17,7 +17,7 @@ createdAt: "2025-06-26T07:48:12.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/pod-security-vpol/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml" target="-blank">/pod-security-vpol/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-seccomp-strict

--- a/src/content/policies/pod-security-vpol/restricted/restrict-volume-types/restrict-volume-types.md
+++ b/src/content/policies/pod-security-vpol/restricted/restrict-volume-types/restrict-volume-types.md
@@ -18,7 +18,7 @@ createdAt: "2025-06-26T07:48:12.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/pod-security-vpol/restricted/restrict-volume-types/restrict-volume-types.yaml" target="-blank">/pod-security-vpol/restricted/restrict-volume-types/restrict-volume-types.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-volume-types

--- a/src/content/policies/psa-mpol/add-privileged-existing-namespaces/add-privileged-existing-namespaces.md
+++ b/src/content/policies/psa-mpol/add-privileged-existing-namespaces/add-privileged-existing-namespaces.md
@@ -17,7 +17,7 @@ createdAt: "2025-10-30T08:57:55.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/psa-mpol/add-privileged-existing-namespaces/add-privileged-existing-namespaces.yaml" target="-blank">/psa-mpol/add-privileged-existing-namespaces/add-privileged-existing-namespaces.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-privileged-existing-namespaces

--- a/src/content/policies/psa-mpol/add-psa-labels/add-psa-labels.md
+++ b/src/content/policies/psa-mpol/add-psa-labels/add-psa-labels.md
@@ -18,7 +18,7 @@ createdAt: "2025-10-30T08:57:55.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/psa-mpol/add-psa-labels/add-psa-labels.yaml" target="-blank">/psa-mpol/add-psa-labels/add-psa-labels.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-psa-labels

--- a/src/content/policies/psp-migration-mpol/add-apparmor/add-apparmor.md
+++ b/src/content/policies/psp-migration-mpol/add-apparmor/add-apparmor.md
@@ -17,7 +17,7 @@ createdAt: "2025-11-14T18:23:14.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/psp-migration-mpol/add-apparmor/add-apparmor.yaml" target="-blank">/psp-migration-mpol/add-apparmor/add-apparmor.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-apparmor-annotations

--- a/src/content/policies/psp-migration-mpol/add-capabilities/add-capabilities.md
+++ b/src/content/policies/psp-migration-mpol/add-capabilities/add-capabilities.md
@@ -16,7 +16,7 @@ createdAt: "2025-11-14T18:23:14.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/psp-migration-mpol/add-capabilities/add-capabilities.yaml" target="-blank">/psp-migration-mpol/add-capabilities/add-capabilities.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-capabilities

--- a/src/content/policies/psp-migration-mpol/add-runtimeClassName/add-runtimeClassName.md
+++ b/src/content/policies/psp-migration-mpol/add-runtimeClassName/add-runtimeClassName.md
@@ -16,7 +16,7 @@ createdAt: "2025-10-30T08:57:55.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/psp-migration-mpol/add-runtimeClassName/add-runtimeClassName.yaml" target="-blank">/psp-migration-mpol/add-runtimeClassName/add-runtimeClassName.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-runtimeclassname

--- a/src/content/policies/velero-mpol/backup-all-volumes/backup-all-volumes.md
+++ b/src/content/policies/velero-mpol/backup-all-volumes/backup-all-volumes.md
@@ -19,7 +19,7 @@ createdAt: "2025-11-14T18:23:14.000Z"
 <a href="https://github.com/kyverno/policies/raw/main/velero-mpol/backup-all-volumes/backup-all-volumes.yaml" target="-blank">/velero-mpol/backup-all-volumes/backup-all-volumes.yaml</a>
 
 ```yaml
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: backup-all-volumes


### PR DESCRIPTION
## Related issue

Fixes #1824

## Proposed Changes

Upgraded all CEL policy samples from `apiVersion: policies.kyverno.io/v1alpha1` to `policies.kyverno.io/v1` across the website documentation.

**Changes include:**
- Updated 159 policy sample pages under `src/content/policies/**`
- Updated docs examples (Quick Start, Exceptions guide, kyverno-cli docs)
- **Note:** Blog posts for 1.14 and 1.15 releases were kept at `v1alpha1` since that's what shipped with those versions

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.