### PR TITLE
fix: broken link to policy on Policy Settings page

### DIFF
--- a/src/content/docs/docs/policy-types/cluster-policy/policy-settings.md
+++ b/src/content/docs/docs/policy-types/cluster-policy/policy-settings.md
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 ---
 
-A [policy](/docs/policy-types/cluster-policy/overview) contains one or more rules, and the following common settings which apply to all rules in the policy:
+A [policy](/policies/) contains one or more rules, and the following common settings which apply to all rules in the policy:
 
 - **admission**: determines whether rules in this policy should be applied during admission control. This is an optional field with a default of `true`. If set to `false` then policies should be applied in background mode only (see further below).
 


### PR DESCRIPTION
## Related issue

Fixes #1648

## Proposed Changes

Fixed broken link from `/docs/policy-types/cluster-policy/overview` to `/policies/` on the Policy Settings page.

File changed: `src/content/docs/docs/policy-types/cluster-policy/policy-settings.md`

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.