### PR TITLE
fix: indent of sample manifest

### DIFF
--- a/src/content/docs/docs/policy-types/mutating-policy.mdx
+++ b/src/content/docs/docs/policy-types/mutating-policy.mdx
@@ -229,7 +229,7 @@ spec:
             metadata: Object.metadata{
               labels: {"managed": "true"}
             }
-          } : 
+          } :
           Object{
             metadata: Object.metadata{
               labels: {"environment": "dev", "managed": "true"}
@@ -484,14 +484,14 @@ spec:
         resources: ['namespaces']
         resourceNames: ['test-namespace']
   targetMatchConstraints:
-  namespaceSelector:
-    matchLabels:
-      test: 'enabled'
-    resourceRules:
-      - apiGroups: ['']
-        apiVersions: ['v1']
-        operations: ['CREATE', 'UPDATE']
-        resources: ['configmaps']
+    namespaceSelector:
+      matchLabels:
+        test: 'enabled'
+      resourceRules:
+        - apiGroups: ['']
+          apiVersions: ['v1']
+          operations: ['CREATE', 'UPDATE']
+          resources: ['configmaps']
   mutations:
     - patchType: ApplyConfiguration
       applyConfiguration:


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Proposed Changes

a tiny fix I've come across while reading the page

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
