### PR TITLE
docs: update metrics documentation

### DIFF
--- a/src/content/docs/docs/guides/monitoring.md
+++ b/src/content/docs/docs/guides/monitoring.md
@@ -180,7 +180,7 @@ Disabling select metrics with [DataDog OpenMetrics](https://docs.datadoghq.com/i
 - [`kyverno_policy_rule_info_total`](/docs/reference/metrics#policies-and-rules-count) - Policies and Rules Count
 - [`kyverno_admission_requests`](/docs/reference/metrics#admission-requests-count) - Admission Requests Count
 - [`kyverno_policy_changes`](/docs/reference/metrics#policy-changes-count) - Policy Changes Count
-- [`kyverno_policy_results`](/docs/reference/metrics#policy-and-rule-execution) - Policy and Rule Execution
+- [`kyverno_policy_results_total`](/docs/reference/metrics#policy-and-rule-execution) - Policy and Rule Execution
 
 ```yaml
 apiVersion: v1
@@ -203,17 +203,12 @@ metadata:
               "exclude_labels": [                                                                                                                            
                 "resource_namespace"                                                                                                                         
               ]                                                                                                                                              
-            },                                                                                                                                               
+            },                                                                                                                                                
             {                                                                                                                                                
               "openmetrics_endpoint": "http://%%host%%:8000/metrics",                                                                                        
               "namespace": "kyverno",                                                                                                                        
               "metrics": [                                                                                                                                   
-                {"kyverno_policy_results": "policy_results"}                                                                                                 
-              ]                                                                                                                                              
-            }                                                                                                                                                
-          ]                                                                                                                                                  
-        }                                                                                                                                                    
-      }
+                {"kyverno_policy_results_total": "policy_results"}                                                                                                 
 ```
 
 The Kyverno Helm chart supports including additional Pod annotations in the values file as shown in the below example.
@@ -223,7 +218,7 @@ The Kyverno Helm chart supports including additional Pod annotations in the valu
 - [`kyverno_policy_rule_info_total`](/docs/reference/metrics#policies-and-rules-count) - Policies and Rules Count
 - [`kyverno_admission_requests`](/docs/reference/metrics#admission-requests-count) - Admission Requests Count
 - [`kyverno_policy_changes`](/docs/reference/metrics#policy-changes-count) - Policy Changes Count
-- [`kyverno_policy_results`](/docs/reference/metrics#policy-and-rule-execution) - Policy and Rule Execution
+- [`kyverno_policy_results_total`](/docs/reference/metrics#policy-and-rule-execution) - Policy and Rule Execution
 
 ```yaml
 podAnnotations:
@@ -250,7 +245,7 @@ podAnnotations:
             "openmetrics_endpoint": "http://%%host%%:8000/metrics",
             "namespace": "kyverno",
             "metrics": [
-              {"kyverno_policy_results": "policy_results"}
+              {"kyverno_policy_results_total": "policy_results"}
             ]
           }
         ]

--- a/src/content/docs/docs/reference/metrics.md
+++ b/src/content/docs/docs/reference/metrics.md
@@ -62,7 +62,7 @@ Gauge - `1` for rules currently actively present in the cluster.
 
 #### Metric Name(s)
 
-- `kyverno_policy_results`
+- `kyverno_policy_results_total`
 
 #### Metric Value
 
@@ -95,13 +95,13 @@ Counter - An only-increasing integer representing the number of results/executio
 #### Useful Queries
 
 - Tracking the total number of rules which failed in the 24 hours in "default" namespace grouped by their rule types (validate, mutate, generate):<br>
-  `sum(increase(kyverno_policy_results{policy_namespace="default", rule_result="fail"}[24h])) by (rule_type)`
+  `sum(increase(kyverno_policy_results_total{policy_namespace="default", rule_result="fail"}[24h])) by (rule_type)`
 
 - Tracking the per-minute rate of the number of rule executions triggered by incoming Pod requests over the cluster:<br>
-  `rate(kyverno_policy_results{resource_kind="Pod", rule_execution_cause="admission_request"}[1m])*60`
+  `rate(kyverno_policy_results_total{resource_kind="Pod", rule_execution_cause="admission_request"}[1m])*60`
 
 - Tracking the total number of policies over the cluster running as a part of background scans over the last 2 hours:<br>
-  `count(increase(kyverno_policy_results{rule_execution_cause="background_scan"}[2h]) by (policy_name))`
+  `count(increase(kyverno_policy_results_total{rule_execution_cause="background_scan"}[2h]) by (policy_name))`
 
 ---
 


### PR DESCRIPTION
## Related Issue

Fixes #1792  

---

## Proposed Changes

This PR updates the Kyverno metrics documentation to clearly include and demonstrate the usage of `kyverno_policy_results_total` alongside `kyverno_policy_results`.

### Key Updates

- Updated the metrics list to include `kyverno_policy_results_total` with consistent naming and references.
- Improved the Helm chart annotation example to correctly show both `kyverno_policy_results` and `kyverno_policy_results_total`.
- Enhanced Prometheus query examples to demonstrate the usage of both metrics in real-world monitoring scenarios.
- Updated the metrics reference section to reflect accurate metric names and queries.

### Motivation

The existing documentation primarily focused on `kyverno_policy_results`, which could lead to confusion when users encounter `kyverno_policy_results_total` in monitoring setups.  
By explicitly documenting both metrics and aligning examples, this change improves clarity, correctness, and usability of the Kyverno metrics documentation.

### Visual Reference
<img width="1414" height="787" alt="kyverno" src="https://github.com/user-attachments/assets/4b495910-2094-47e8-9299-bea58e2b2f90" />
---

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.