### PR TITLE
Fix: correct kyverno_policy_results metric name to include _total suffix

### DIFF
--- a/src/content/docs/docs/guides/monitoring.md
+++ b/src/content/docs/docs/guides/monitoring.md
@@ -180,7 +180,7 @@ Disabling select metrics with [DataDog OpenMetrics](https://docs.datadoghq.com/i
 - [`kyverno_policy_rule_info_total`](/docs/reference/metrics#policies-and-rules-count) - Policies and Rules Count
 - [`kyverno_admission_requests`](/docs/reference/metrics#admission-requests-count) - Admission Requests Count
 - [`kyverno_policy_changes`](/docs/reference/metrics#policy-changes-count) - Policy Changes Count
-- [`kyverno_policy_results`](/docs/reference/metrics#policy-and-rule-execution) - Policy and Rule Execution
+- [`kyverno_policy_results_total`](/docs/reference/metrics#policy-and-rule-execution) - Policy and Rule Execution
 
 ```yaml
 apiVersion: v1
@@ -208,7 +208,7 @@ metadata:
               "openmetrics_endpoint": "http://%%host%%:8000/metrics",                                                                                        
               "namespace": "kyverno",                                                                                                                        
               "metrics": [                                                                                                                                   
-                {"kyverno_policy_results": "policy_results"}                                                                                                 
+                {"kyverno_policy_results_total": "policy_results"}                                                                                                 
               ]                                                                                                                                              
             }                                                                                                                                                
           ]                                                                                                                                                  
@@ -223,7 +223,7 @@ The Kyverno Helm chart supports including additional Pod annotations in the valu
 - [`kyverno_policy_rule_info_total`](/docs/reference/metrics#policies-and-rules-count) - Policies and Rules Count
 - [`kyverno_admission_requests`](/docs/reference/metrics#admission-requests-count) - Admission Requests Count
 - [`kyverno_policy_changes`](/docs/reference/metrics#policy-changes-count) - Policy Changes Count
-- [`kyverno_policy_results`](/docs/reference/metrics#policy-and-rule-execution) - Policy and Rule Execution
+- [`kyverno_policy_results_total`](/docs/reference/metrics#policy-and-rule-execution) - Policy and Rule Execution
 
 ```yaml
 podAnnotations:
@@ -250,7 +250,7 @@ podAnnotations:
             "openmetrics_endpoint": "http://%%host%%:8000/metrics",
             "namespace": "kyverno",
             "metrics": [
-              {"kyverno_policy_results": "policy_results"}
+              {"kyverno_policy_results_total": "policy_results"}
             ]
           }
         ]

--- a/src/content/docs/docs/reference/metrics.md
+++ b/src/content/docs/docs/reference/metrics.md
@@ -62,7 +62,7 @@ Gauge - `1` for rules currently actively present in the cluster.
 
 #### Metric Name(s)
 
-- `kyverno_policy_results`
+- `kyverno_policy_results_total`
 
 #### Metric Value
 
@@ -95,13 +95,13 @@ Counter - An only-increasing integer representing the number of results/executio
 #### Useful Queries
 
 - Tracking the total number of rules which failed in the 24 hours in "default" namespace grouped by their rule types (validate, mutate, generate):<br>
-  `sum(increase(kyverno_policy_results{policy_namespace="default", rule_result="fail"}[24h])) by (rule_type)`
+  `sum(increase(kyverno_policy_results_total{policy_namespace="default", rule_result="fail"}[24h])) by (rule_type)`
 
 - Tracking the per-minute rate of the number of rule executions triggered by incoming Pod requests over the cluster:<br>
-  `rate(kyverno_policy_results{resource_kind="Pod", rule_execution_cause="admission_request"}[1m])*60`
+  `rate(kyverno_policy_results_total{resource_kind="Pod", rule_execution_cause="admission_request"}[1m])*60`
 
 - Tracking the total number of policies over the cluster running as a part of background scans over the last 2 hours:<br>
-  `count(increase(kyverno_policy_results{rule_execution_cause="background_scan"}[2h]) by (policy_name))`
+  `count(increase(kyverno_policy_results_total{rule_execution_cause="background_scan"}[2h]) by (policy_name))`
 
 ---
 


### PR DESCRIPTION
## Summary

This PR fixes the metric name in the documentation from `kyverno_policy_results` to `kyverno_policy_results_total` to match the actual metric name exposed by Kyverno in Prometheus.

## Changes

- Updated metric name in the Policy and Rule Execution section of the metrics reference documentation
- Updated all three Prometheus query examples to use `kyverno_policy_results_total`
- Updated DataDog OpenMetrics configuration examples in the monitoring guide

## Why

In Prometheus, counter metrics conventionally have a `_total` suffix. The documentation was showing `kyverno_policy_results`, but Kyverno actually exposes this metric as `kyverno_policy_results_total` in Prometheus 1.16.

## Files Modified

- `src/content/docs/docs/reference/metrics.md`
- `src/content/docs/docs/guides/monitoring.md`

Fixes #1792