### PR TITLE
fix: Too many redirects on sigstore/notary CPOL pages

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -36,7 +36,7 @@
   [context.branch-deploy.environment]
     NODE_ENV = "production"
     ASTRO_ENV = "branch"
-    SITE_URL = "$DEPLOY_PRIME_URL" 
+    SITE_URL = "$DEPLOY_PRIME_URL"
 
 # --- Documentation reorganization redirects (commit f4503dcc) ---
 # Applying policies - deleted, moved to guides
@@ -220,20 +220,8 @@
   force = true
 
 [[redirects]]
-  from = "/docs/policy-types/cluster-policy/verify-images/notary"
-  to = "/docs/policy-types/cluster-policy/verify-images/notary"
-  status = 301
-  force = true
-
-[[redirects]]
   from = "/docs/policy-types/cluster-policy/verify-images/notary/*"
   to = "/docs/policy-types/cluster-policy/verify-images/notary"
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "/docs/policy-types/cluster-policy/verify-images/sigstore"
-  to = "/docs/policy-types/cluster-policy/verify-images/sigstore"
   status = 301
   force = true
 


### PR DESCRIPTION
## Related issue

When going to https://kyverno.io/docs/policy-types/cluster-policy/verify-images/sigstore we get `ERR_TOO_MANY_REDIRECTS` error because of bad redirects in netlify
