### PR TITLE
docs: add CEL Getting Started and Comparison guides

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -104,7 +104,7 @@ export default defineConfig({
               ],
               collapsed: true,
               badge: {
-                text: 'Deprecated',
+                text: 'Legacy',
                 variant: 'caution',
               },
             },
@@ -116,6 +116,8 @@ export default defineConfig({
           label: 'Guides',
           collapsed: true,
           items: [
+            'docs/guides/cel-getting-started',
+            'docs/guides/cel-vs-traditional',
             'docs/guides/migration-to-cel',
             'docs/guides/applying-policies',
             'docs/guides/testing-policies',

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -17,8 +17,7 @@ import {
 import { themes } from 'prism-react-renderer'
 
 export const documentationVersions = [
-  { label: 'v1.17.0', href: 'https://kyverno.io' },
-  { label: 'v1.16.0', href: 'https://release-1-16-0.kyverno.io' },
+  { label: 'v1.16.0', href: 'https://kyverno.io' },
   { label: 'v1.15.0', href: 'https://release-1-15-0.kyverno.io' },
   { label: 'v1.14.0', href: 'https://release-1-14-0.kyverno.io' },
   { label: 'main', href: 'https://main.kyverno.io' },
@@ -40,10 +39,10 @@ export const navItemsExternal = [
 export const whyKyvernoCards = [
   {
     icon: Zap,
-    title: 'Easy to Adopt',
-    desc1: 'Use familiar languages and tools.',
+    title: 'Fast & Efficient',
+    desc1: 'CEL-based policies deliver 25% faster latency.',
     desc2:
-      'Kubernetes-native types that integrate seamlessly into your existing workflows.',
+      'Up to 80% CPU reduction with automatic native Kubernetes policy generation.',
   },
   {
     icon: Shield,
@@ -184,11 +183,10 @@ export const policies = [
 export const heroSectionHeadingContent = {
   headingText: [
     { text: 'Unified', color: 'text-primary-100' },
-    { text: 'Policy as Code,', color: 'text-primary-100' },
-    { text: 'Simplified!', color: 'text-accent-100' },
+    { text: 'Policy as Code', color: 'text-primary-100' },
   ],
 
-  paragraphText: `Secure, automate, and operate all your infrastructure and applications with YAML and CEL based policies.`,
+  paragraphText: `Kubernetes-native policy management. Secure, automate, and operate your infrastructure with CEL standards and Kyverno flexibility.`,
 }
 
 export const whykyvernoHeadingContent = {
@@ -200,30 +198,27 @@ export const whykyvernoHeadingContent = {
 export const comparisonChartHeadingContent = {
   headingText: [
     { text: 'Kyverno vs', color: 'text-primary-100' },
-    { text: 'Other policy engines', color: 'text-primary-100' },
+    { text: 'Alternatives', color: 'text-primary-100' },
   ],
 
-  paragraphText: `As the industry's leading policy engine, here's how Kyverno compares with other popular solutions.`,
+  paragraphText: `Compare Kyverno's capabilities with other policy engines.`,
 }
 
 export const featureSectionHeadingContent = {
   headingText: [
-    { text: 'Complete Platform Engineering', color: 'text-theme-primary' },
-    { text: 'Policy As Code Solution', color: 'text-primary-100' },
+    { text: 'Complete Platform', color: 'text-theme-primary' },
+    { text: 'Governance', color: 'text-primary-100' },
   ],
 
-  paragraphText: `From policy creation to enforcement, testing to reporting, and everything in between,
-                       get comprehensive Kubernetes governance and compliance with Kyverno.`,
+  paragraphText: `Comprehensive Kubernetes governance and compliance: from policy creation to enforcement, testing, and reporting.`,
 }
 
 export const celPoliciesHeadingContent = {
   headingText: [
-    { text: 'Introducing', color: 'text-theme-primary' },
-    { text: 'CEL Polices', color: 'text-primary-100' },
+    { text: 'CEL-Powered', color: 'text-theme-primary' },
+    { text: 'Performance', color: 'text-primary-100' },
   ],
-  paragraphText: `CEL (Common Expression Language) policies bring powerful,
-                    fine-grained control to Kyverno, enabling users to write more
-                    expressive and dynamic policy rules without sacrificing performance. `,
+  paragraphText: `Kyverno v1.16 introduces CEL-based policies for improved latency, reduced resource usage, and native Kubernetes alignment.`,
 }
 
 export const ctaSectionHeadingContent = {
@@ -231,16 +226,15 @@ export const ctaSectionHeadingContent = {
     { text: 'Get started with Kyverno', color: 'text-theme-primary' },
   ],
 
-  paragraphText: `Deploy Kyverno in your Kubernetes cluster within minutes and start writing
-                  policies using simple, familiar YAML.`,
+  paragraphText: `Deploy Kyverno in minutes. Use modern CEL-based policies for optimal performance.`,
 }
 
 export const partnersSectionHeadingContent = {
   headingText: [
-    { text: 'Trusted By Industry Leaders', color: 'text-theme-primary' },
+    { text: 'Trusted by Industry Leaders', color: 'text-theme-primary' },
   ],
 
-  paragraphText: 'Powering Policy-Based Security & Operations Worldwide',
+  paragraphText: 'Powering policy-based security and operations worldwide',
 }
 
 export const codingThemes = {
@@ -261,7 +255,7 @@ export const policyShowcaseTabs = [
     id: 'validate-k8s',
     label: 'Validate Kubernetes Resources',
     learnMore: '/docs/policy-types/validating-policy',
-    policy: `apiVersion: policies.kyverno.io/v1
+    policy: `apiVersion: policies.kyverno.io/v1beta1
 kind: ValidatingPolicy
 metadata:
   name: require-labels
@@ -280,7 +274,7 @@ spec:
   validations:
     -  message: "Pods must have 'app' and 'version' labels"
        expression: |
-         has(variables.labels.app) &&
+         has(variables.labels.app) && 
          has(variables.labels.version)
      `,
   },
@@ -288,7 +282,7 @@ spec:
     id: 'validate-terraform',
     label: 'Validate Terraform Plans',
     learnMore: '/docs/policy-types/validating-policy',
-    policy: `apiVersion: policies.kyverno.io/v1
+    policy: `apiVersion: policies.kyverno.io/v1beta1
 kind: ValidatingPolicy
 metadata:
   name: check-awsvpc-network-mode
@@ -303,7 +297,7 @@ spec:
   variables:
     - name: ecsTasks
       expression: |
-        object.?planned_values.root_module.resources.exists(r,
+        object.?planned_values.root_module.resources.exists(r, 
           r.type == 'aws_ecs_task_definition').orValue([])
   validations:
     - message: "ECS tasks must use awsvpc network mode."
@@ -318,7 +312,7 @@ spec:
     id: 'validate-dockerfile',
     label: 'Validate Dockerfiles',
     learnMore: '/docs/policy-types/validating-policy',
-    policy: `apiVersion: policies.kyverno.io/v1
+    policy: `apiVersion: policies.kyverno.io/v1beta1
 kind: ValidatingPolicy
 metadata:
   name: check-label-maintainer
@@ -332,7 +326,7 @@ spec:
     - message: "MAINTAINER is deprecated, use LABELS instead"
       expression: |
         !object.Stages.exists(stage,
-          has(stage.Commands) &&
+          has(stage.Commands) && 
             stage.Commands.exists(cmd, cmd.Name == 'MAINTAINER')
         )
     - message: "Use the LABELS instruction to set the MAINTAINER name"
@@ -340,8 +334,8 @@ spec:
         object.Stages.exists(stage,
           has(stage.Commands) && stage.Commands.exists(cmd,
             has(cmd.Labels) && cmd.Labels.exists(label,
-              label.Key == 'maintainer' ||
-              label.Key == 'owner' ||
+              label.Key == 'maintainer' || 
+              label.Key == 'owner' || 
               label.Key == 'author'
             )
           )
@@ -351,15 +345,15 @@ spec:
     id: 'validate-http',
     label: 'Authorize HTTP Requests',
     learnMore: '/docs/policy-types/validating-policy',
-    policy: `apiVersion: policies.kyverno.io/v1
+    policy: `apiVersion: policies.kyverno.io/v1beta1
 kind: ValidatingPolicy
 metadata:
   name: authorize-jwt
 spec:
   evaluation:
     mode: "HTTP"
-  failurePolicy: Fail
-  variables:
+  failurePolicy: Fail 
+  variables: 
   - name: authorizationlist
     expression: object.attributes.Header("authorization")
   - name: authorization
@@ -369,11 +363,11 @@ spec:
         : []
   - name: token
     expression: >
-      size(variables.authorization) == 2 &&
+      size(variables.authorization) == 2 && 
         variables.authorization[0].lowerAscii() == "bearer"
           ? jwt.Decode(variables.authorization[1], "secret")
           : null
-  validations:
+  validations: 
     # request not authenticated -> 401
   - expression: >
       variables.token == null || !variables.token.Valid
@@ -392,7 +386,7 @@ spec:
     id: 'validate-envoy',
     label: 'Authorize Envoy Requests',
     learnMore: '/docs/policy-types/validating-policy',
-    policy: `apiVersion: policies.kyverno.io/v1
+    policy: `apiVersion: policies.kyverno.io/v1beta1
 kind: ValidatingPolicy
 metadata:
   name: check-envoy-request
@@ -415,7 +409,7 @@ spec:
     id: 'mutate-k8s',
     label: 'Mutate Kubernetes Resources',
     learnMore: '/docs/policy-types/mutating-policy',
-    policy: `apiVersion: policies.kyverno.io/v1
+    policy: `apiVersion: policies.kyverno.io/v1beta1
 kind: MutatingPolicy
 metadata:
   name: add-safe-to-evict
@@ -429,11 +423,11 @@ spec:
   matchConditions:
     - name: has-emptydir-or-hostpath
       expression: |
-        has(object.spec.volumes) &&
+        has(object.spec.volumes) && 
         object.spec.volumes.exists(v, has(v.emptyDir) || has(v.hostPath))
     - name: annotation-not-present
       expression: |
-        !has(object.metadata.annotations) ||
+        !has(object.metadata.annotations) || 
         !object.metadata.annotations.exists(k, k == 'cluster-autoscaler.kubernetes.io/safe-to-evict')
   mutations:
     - patchType: ApplyConfiguration
@@ -451,7 +445,7 @@ spec:
     id: 'generate-k8s',
     label: 'Generate Kubernetes Resources',
     learnMore: '/docs/policy-types/generating-policy',
-    policy: `apiVersion: policies.kyverno.io/v1
+    policy: `apiVersion: policies.kyverno.io/v1beta1
 kind: GeneratingPolicy
 metadata:
   name: add-networkpolicy
@@ -490,7 +484,7 @@ spec:
     id: 'cleanup-k8s',
     label: 'Cleanup Kubernetes Resources',
     learnMore: '/docs/policy-types/cleanup-policy',
-    policy: `apiVersion: policies.kyverno.io/v1
+    policy: `apiVersion: policies.kyverno.io/v1beta1
 kind: DeletingPolicy
 metadata:
   name: cleanup-empty-replicasets
@@ -515,7 +509,7 @@ spec:
     id: 'validate-images',
     label: 'Validate Container Images',
     learnMore: '/docs/policy-types/image-validating-policy',
-    policy: `apiVersion: policies.kyverno.io/v1
+    policy: `apiVersion: policies.kyverno.io/v1alpha1
 kind: ImageValidatingPolicy
 metadata:
   name: verify-image-ivpol
@@ -546,7 +540,7 @@ spec:
   validations:
     - message: image is not authorized
       expression: |
-       images.containers.map(image,
+       images.containers.map(image, 
          verifyImageSignatures(image, [attestors.cosign])).all(e ,e > 0)`,
   },
 ]

--- a/src/content/docs/docs/guides/cel-getting-started.md
+++ b/src/content/docs/docs/guides/cel-getting-started.md
@@ -1,0 +1,283 @@
+---
+title: Getting Started with CEL Policies
+description: >-
+  A beginner-friendly introduction to writing CEL-based policies in Kyverno
+sidebar:
+  order: 11
+---
+
+Common Expression Language (CEL) is the standard for writing performant, native policies in Kyverno and Kubernetes.
+
+## Why CEL?
+
+CEL-based policies provide:
+
+| Benefit | Description |
+|---------|-------------|
+| **Performance** | Improved latency and reduced CPU usage |
+| **Kubernetes Native** | Aligns with ValidatingAdmissionPolicy |
+| **Expressiveness** | Flexible validation logic |
+| **Auto-Generation** | Generates native Kubernetes admission policies |
+
+## Creating a Policy
+
+This example demonstrates a validation policy that checks for required labels.
+
+### Structure
+
+A CEL-based `ValidatingPolicy` includes the following components:
+
+```yaml
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: require-app-label
+spec:
+  validationActions:
+    - Deny                    # Action on failure: Deny, Audit, or Warn
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ['']
+        apiVersions: ['v1']
+        operations: ['CREATE', 'UPDATE']
+        resources: ['pods']   # Target resources
+  validations:
+    - expression: "has(object.metadata.labels.app)"
+      message: "Pods must have an 'app' label"
+```
+
+### Apply and Test
+
+1. Save `require-app-label.yaml`.
+2. Apply the policy: `kubectl apply -f require-app-label.yaml`.
+3. Test with a non-compliant pod:
+
+```yaml
+# Denied
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+    - name: nginx
+      image: nginx:latest
+```
+
+```yaml
+# Allowed
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  labels:
+    app: my-app
+spec:
+  containers:
+    - name: nginx
+      image: nginx:latest
+```
+
+## CEL Expressions
+
+References for common CEL operations:
+
+### Accessing Fields
+
+```cel
+# Resource context
+object.metadata.name                    # Pod name
+object.metadata.namespace               # Namespace
+object.metadata.labels                  # All labels
+object.spec.containers                  # Container list
+```
+
+### Checking Existence
+
+```cel
+# Check field existence
+has(object.metadata.labels)
+has(object.metadata.labels.app)
+
+# Safe access (returns empty object if null)
+object.metadata.?labels.orValue({})
+```
+
+### Operators
+
+```cel
+# Comparison
+object.spec.replicas > 1
+
+# Logical
+condition1 && condition2
+condition1 || condition2
+!condition
+
+# String operations
+object.metadata.name.startsWith("app-")
+```
+
+### Lists
+
+```cel
+# Check all items
+object.spec.containers.all(c, has(c.resources))
+
+# Check existence in list
+object.spec.containers.exists(c, c.image.contains("nginx"))
+```
+
+## Policy Patterns
+
+### Require Labels
+
+```yaml
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: require-labels
+spec:
+  validationActions: [Deny]
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ['']
+        apiVersions: ['v1']
+        operations: ['CREATE', 'UPDATE']
+        resources: ['pods']
+  validations:
+    - expression: |
+        has(object.metadata.labels.app) &&
+        has(object.metadata.labels.env)
+      message: "Pods must have 'app' and 'env' labels"
+```
+
+### Restrict Container Images
+
+```yaml
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: restrict-image-registries
+spec:
+  validationActions: [Deny]
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ['']
+        apiVersions: ['v1']
+        operations: ['CREATE', 'UPDATE']
+        resources: ['pods']
+  validations:
+    - expression: |
+        object.spec.containers.all(c,
+          c.image.startsWith("ghcr.io/") ||
+          c.image.startsWith("docker.io/library/")
+        )
+      message: "Images must be from approved registries (ghcr.io or docker.io/library)"
+```
+
+### Require Resource Limits
+
+```yaml
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: require-resource-limits
+spec:
+  validationActions: [Deny]
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ['']
+        apiVersions: ['v1']
+        operations: ['CREATE', 'UPDATE']
+        resources: ['pods']
+  validations:
+    - expression: |
+        object.spec.containers.all(c,
+          has(c.resources) &&
+          has(c.resources.limits) &&
+          has(c.resources.limits.memory) &&
+          has(c.resources.limits.cpu)
+        )
+      message: "All containers must have CPU and memory limits"
+```
+
+### Block Latest Tag
+
+```yaml
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: disallow-latest-tag
+spec:
+  validationActions: [Deny]
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ['']
+        apiVersions: ['v1']
+        operations: ['CREATE', 'UPDATE']
+        resources: ['pods']
+  validations:
+    - expression: |
+        object.spec.containers.all(c,
+          !c.image.endsWith(":latest") &&
+          c.image.contains(":")
+        )
+      message: "Container images must use a specific tag, not 'latest'"
+```
+
+## Using Variables
+
+Variables simplify complex expressions:
+
+```yaml
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: validate-deployment
+spec:
+  validationActions: [Deny]
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ['apps']
+        apiVersions: ['v1']
+        operations: ['CREATE', 'UPDATE']
+        resources: ['deployments']
+  variables:
+    - name: containers
+      expression: "object.spec.template.spec.containers"
+    - name: labels
+      expression: "object.metadata.?labels.orValue({})"
+  validations:
+    - expression: "'app' in variables.labels"
+      message: "Deployment must have an 'app' label"
+    - expression: |
+        variables.containers.all(c, has(c.resources))
+      message: "All containers must have resource specifications"
+```
+
+## Built-in Variables
+
+| Variable | Description |
+|----------|-------------|
+| `object` | The resource being validated |
+| `oldObject` | Previous version (for UPDATE operations) |
+| `request` | Admission request data |
+| `request.operation` | Operation type (CREATE, UPDATE, DELETE, CONNECT) |
+| `request.userInfo` | Requestor information |
+
+## Next Steps
+
+- [ValidatingPolicy](/docs/policy-types/validating-policy)
+- [MutatingPolicy](/docs/policy-types/mutating-policy)
+- [GeneratingPolicy](/docs/policy-types/generating-policy)
+- [CEL Libraries](/docs/policy-types/cel-libraries)
+- [Variables Reference](/docs/cel/variables-reference)- [Migration Guide](/docs/migration/traditional-to-cel) - Migrate existing policies to CEL
+
+## Tips for Success
+
+1. **Start Simple**: Begin with basic validation rules and add complexity gradually
+2. **Use Variables**: Break complex expressions into named variables for clarity
+3. **Test Thoroughly**: Use the Kyverno CLI to test policies before deploying
+4. **Enable Audit Mode**: Start with `Audit` validation action to observe without blocking
+5. **Check Logs**: Review Kyverno logs for policy evaluation details

--- a/src/content/docs/docs/guides/cel-vs-traditional.md
+++ b/src/content/docs/docs/guides/cel-vs-traditional.md
@@ -1,0 +1,321 @@
+---
+title: CEL vs Traditional Policies
+description: >-
+  Comparison between CEL-based policies and traditional ClusterPolicy/Policy
+sidebar:
+  order: 15
+---
+
+Kyverno supports two policy definitions: **CEL-based policies** (ValidatingPolicy, MutatingPolicy, etc.) and **Traditional ClusterPolicy/Policy** resources. This guide outlines the key differences.
+
+## Feature Comparison
+
+| Feature | CEL-based Policies | Traditional Policies |
+|---------|-------------------|---------------------|
+| **API Version** | `policies.kyverno.io/v1` | `kyverno.io/v1` |
+| **Logic** | CEL (Common Expression Language) | YAML patterns, JMESPath |
+| **Performance** | High (compiled) | Standard |
+| **K8s Native** | Aligns with ValidatingAdmissionPolicy | Custom Resource |
+| **Status** | Stable (v1) | Stable (v1) |
+
+## Policy Types
+
+| Purpose | CEL Policy | Traditional Equivalent |
+|---------|------------|------------------------|
+| Validation | `ValidatingPolicy` | `ClusterPolicy` (validate) |
+| Mutation | `MutatingPolicy` | `ClusterPolicy` (mutate) |
+| Generation | `GeneratingPolicy` | `ClusterPolicy` (generate) |
+| Cleanup | `DeletingPolicy` | `CleanupPolicy` |
+| Images | `ImageValidatingPolicy` | `ClusterPolicy` (verifyImages) |
+
+## Examples
+
+### Validation: Require Labels
+
+**Traditional ClusterPolicy:**
+
+```yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-labels
+spec:
+  validationFailureAction: Enforce
+  rules:
+    - name: check-labels
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: "Labels 'app' and 'env' are required"
+        pattern:
+          metadata:
+            labels:
+              app: "?*"
+              env: "?*"
+```
+
+**CEL-based ValidatingPolicy:**
+
+```yaml
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: require-labels
+spec:
+  validationActions: [Deny]
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ['']
+        apiVersions: ['v1']
+        operations: ['CREATE', 'UPDATE']
+        resources: ['pods']
+  validations:
+    - expression: |
+        has(object.metadata.labels.app) &&
+        has(object.metadata.labels.env)
+      message: "Labels 'app' and 'env' are required"
+```
+
+### Validation: Block Latest Tag
+
+**Traditional ClusterPolicy:**
+
+```yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-latest
+spec:
+  validationFailureAction: Enforce
+  rules:
+    - name: no-latest
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: "Using 'latest' tag is not allowed"
+        pattern:
+          spec:
+            containers:
+              - image: "!*:latest"
+```
+
+**CEL-based ValidatingPolicy:**
+
+```yaml
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: disallow-latest
+spec:
+  validationActions: [Deny]
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ['']
+        apiVersions: ['v1']
+        operations: ['CREATE', 'UPDATE']
+        resources: ['pods']
+  validations:
+    - expression: |
+        object.spec.containers.all(c, !c.image.endsWith(":latest"))
+      message: "Using 'latest' tag is not allowed"
+```
+
+### Mutation: Add Labels
+
+**Traditional ClusterPolicy:**
+
+```yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-labels
+spec:
+  rules:
+    - name: add-team-label
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            labels:
+              team: platform
+```
+
+**CEL-based MutatingPolicy:**
+
+```yaml
+apiVersion: policies.kyverno.io/v1
+kind: MutatingPolicy
+metadata:
+  name: add-labels
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ['']
+        apiVersions: ['v1']
+        operations: ['CREATE']
+        resources: ['pods']
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: |
+          Object{
+            metadata: Object.metadata{
+              labels: Object.metadata.labels{
+                team: "platform"
+              }
+            }
+          }
+```
+
+### Generation: Clone Secrets
+
+**Traditional ClusterPolicy:**
+
+```yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: clone-secret
+spec:
+  rules:
+    - name: clone-regcred
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+      generate:
+        synchronize: true
+        apiVersion: v1
+        kind: Secret
+        name: regcred
+        namespace: "{{request.object.metadata.name}}"
+        clone:
+          namespace: default
+          name: regcred
+```
+
+**CEL-based GeneratingPolicy:**
+
+```yaml
+apiVersion: policies.kyverno.io/v1
+kind: GeneratingPolicy
+metadata:
+  name: clone-secret
+spec:
+  evaluation:
+    synchronize:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ['']
+        apiVersions: ['v1']
+        operations: ['CREATE']
+        resources: ['namespaces']
+  variables:
+    - name: targetNs
+      expression: "object.metadata.name"
+    - name: source
+      expression: resource.Get("v1", "secrets", "default", "regcred")
+  generate:
+    - expression: generator.Apply(variables.targetNs, [variables.source])
+```
+
+## Key Differences
+
+### Language
+
+**Traditional:** YAML patterns with wildcards (`?*`, `!*:latest`) and JMESPath (`{{ request.object.metadata.name }}`).
+
+**CEL-based:** CEL (Common Expression Language), strongly typed and compiled.
+
+### Matching
+
+**Traditional:**
+```yaml
+match:
+  any:
+    - resources:
+        kinds:
+          - Pod
+```
+
+**CEL-based:**
+```yaml
+matchConstraints:
+  resourceRules:
+    - apiGroups: ['']
+      apiVersions: ['v1']
+      operations: ['CREATE', 'UPDATE']
+      resources: ['pods']
+```
+
+### Actions
+
+**Traditional:** `validationFailureAction: Enforce` or `Audit`.
+
+**CEL-based:** `validationActions: [Deny, Audit, Warn]`.
+
+## Usage Recommendations
+
+**Use CEL-based policies for:**
+
+- New deployments
+- High-performance requirements
+- Complex validation logic
+- Native K8s policy generation
+- Non-Kubernetes payloads (Terraform, JSON)
+
+**Use Traditional policies for:**
+
+- Existing stable deployments
+- Simple pattern matching
+- Teams preferring YAML-only syntax
+✅ **Choose traditional policies when:**
+
+- You have existing policies that work well
+- Simple pattern matching is sufficient
+- Your team is more comfortable with YAML patterns
+- You need features only available in traditional policies
+
+## Migration Path
+
+If you're considering migrating from traditional to CEL-based policies:
+
+1. **Start with new policies** - Write new policies using CEL
+2. **Run in parallel** - Both policy types can coexist
+3. **Migrate gradually** - Convert policies one at a time
+4. **Use the migration guide** - See [Migrating from Traditional to CEL](/docs/migration/traditional-to-cel)
+
+## Feature Availability
+
+| Feature | CEL-based | Traditional |
+|---------|-----------|-------------|
+| Validate resources | ✅ ValidatingPolicy | ✅ ClusterPolicy validate |
+| Mutate resources | ✅ MutatingPolicy | ✅ ClusterPolicy mutate |
+| Generate resources | ✅ GeneratingPolicy | ✅ ClusterPolicy generate |
+| Delete resources | ✅ DeletingPolicy | ✅ CleanupPolicy |
+| Verify images | ✅ ImageValidatingPolicy | ✅ ClusterPolicy verifyImages |
+| Policy exceptions | ✅ PolicyException | ✅ PolicyException |
+| Background scans | ✅ | ✅ |
+| Auto-gen for pod controllers | ✅ | ✅ |
+| Generate ValidatingAdmissionPolicy | ✅ | ❌ |
+| Generate MutatingAdmissionPolicy | ✅ | ❌ |
+| JSON/YAML payload validation | ✅ | Limited |
+| External data (API calls) | ✅ | ✅ |
+
+## Conclusion
+
+CEL-based policies represent the future direction of Kyverno and offer significant advantages in performance, Kubernetes alignment, and expressiveness. However, traditional policies remain fully supported and are appropriate for many use cases, especially when simplicity and familiarity are priorities.
+
+For new deployments and performance-critical environments, we recommend CEL-based policies. For existing deployments with working traditional policies, migration can be gradual based on your needs.

--- a/src/content/docs/docs/guides/exceptions.md
+++ b/src/content/docs/docs/guides/exceptions.md
@@ -855,7 +855,7 @@ Kyverno supports narrowly scoped, CEL-aware exceptions so you can permit specifi
 This exception allows Pods in the `ci` namespace to use images matching the provided patterns while keeping the “no latest tag” guardrail enforced for all others. The match condition narrows the bypass to a specific team for auditability.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1beta1
+apiVersion: policies.kyverno.io/v1
 kind: PolicyException
 metadata:
   name: allow-ci-latest-images
@@ -873,7 +873,7 @@ spec:
 The following `ValidatingPolicy` references `exceptions.allowedImages` to skip validation checks for whitelisted image(s).
 
 ```yaml
-apiVersion: policies.kyverno.io/v1beta1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-image-tag
@@ -904,7 +904,7 @@ spec:
 This exception supplies a list of values via `allowedValues` that a CEL validation may accept for a constrained set of targets so teams can proceed without weakening the entire policy.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1beta1
+apiVersion: policies.kyverno.io/v1
 kind: PolicyException
 metadata:
   name: allow-debug-annotation
@@ -922,7 +922,7 @@ spec:
 Here’s the policy leveraging the above allowed values. It denies resources unless the annotation/capability value is present in `exceptions.allowedValues`.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1beta1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-security-context
@@ -953,7 +953,7 @@ spec:
 Use `reportResult` in a `PolicyException` to control how matches appear in PolicyReports. Setting `reportResult: pass` marks exceptions as “pass” instead of the default “skip”.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1beta1
+apiVersion: policies.kyverno.io/v1
 kind: PolicyException
 metadata:
   name: exclude-skipped-deployment-2

--- a/src/content/docs/docs/policy-types/cel-libraries.mdx
+++ b/src/content/docs/docs/policy-types/cel-libraries.mdx
@@ -456,7 +456,7 @@ The **Hash library** introduces the ability to run hash functions on arbitrary v
 The following policy ensures that the hash of the image name in a certain deployment matches the required value which represents `nginx:latest`:
 
 ```yaml
-apiVersion: policies.kyverno.io/v1beta1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-hash

--- a/src/content/docs/docs/policy-types/deleting-policy.mdx
+++ b/src/content/docs/docs/policy-types/deleting-policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: DeletingPolicy
-excerpt: >-
+description: >-
   Deletes matching resources based on a schedule
 sidebar:
   order: 5
@@ -8,7 +8,7 @@ sidebar:
 
 import FeatureState from '../../../../components/FeatureState.astro'
 
-<FeatureState state="stable" version="v1.17" />
+<FeatureState state="beta" version="v1.16" />
 
 ## Introduction
 
@@ -80,7 +80,7 @@ Both policy types have identical functionality and field structure. The only dif
 ### Example NamespacedDeletingPolicy
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: NamespacedDeletingPolicy
 metadata:
   name: cleanup-jobs
@@ -110,7 +110,7 @@ This `DeletingPolicy` named cleanup-old-test-pods is configured to automatically
 The policy uses a cron schedule to run periodically and applies conditions using CEL expressions to ensure only marked pods are cleaned up. Additionally, it defines a variable (isEphemeral) that could be used to further refine deletion logic, such as deleting only temporary or ephemeral pods.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: DeletingPolicy
 metadata:
   name: cleanup-old-test-pods
@@ -128,7 +128,7 @@ spec:
         environment: test
   conditions:
     - name: isOld
-      expression: "has(object.metadata.labels.old) && object.metadata.labels.old == 'true'"
+      expression: "expression: "has(object.metadata.labels.old) && object.metadata.labels.old == 'true'""
   variables:
     - name: isEphemeral
       expression: "has(object.metadata.labels.ephemeral) && object.metadata.labels.ephemeral == 'true'"
@@ -180,7 +180,7 @@ action: Resource Cleaned Up
 reason: PolicyApplied
 message: successfully deleted the target resource Pod/default/example
 involvedObject:
-  apiVersion: policies.kyverno.io/v1
+  apiVersion: policies.kyverno.io/v1alpha1
   kind: DeletingPolicy
   name: deleting-pod
   uid: cc44fb71-9413-4bbf-bc37-036a10f02c7c

--- a/src/content/docs/docs/policy-types/generating-policy.mdx
+++ b/src/content/docs/docs/policy-types/generating-policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: GeneratingPolicy
-excerpt: >-
+description: >-
   Create or clone resources based on flexible triggers
 sidebar:
   order: 4
@@ -8,7 +8,7 @@ sidebar:
 
 import FeatureState from '../../../../components/FeatureState.astro'
 
-<FeatureState state="stable" version="v1.17" />
+<FeatureState state="beta" version="v1.16" />
 
 The GeneratingPolicy enables the creation of Kubernetes resources using Common Expression Language (CEL) expressions. It provides the same core functionality as Kyverno's [generate rules](/docs/policy-types/cluster-policy/generate), but is designed with a CEL-first approach for improved flexibility, expressiveness, and alignment with Kubernetes' evolving policy standards.
 
@@ -29,7 +29,7 @@ Key Benefits:
 For example, the following policy automatically clones an image pull secret from the default namespace into any newly created Namespace:
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: GeneratingPolicy
 metadata:
   name: clone-image-pull-secret
@@ -80,7 +80,7 @@ The Data Source mode allows users to define the downstream resources directly wi
 The below policy demonstrates how to generate a ConfigMap in response to a Namespace creation:
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: GeneratingPolicy
 metadata:
   name: zk-kafka-address
@@ -132,7 +132,7 @@ To clone a single resource, you can use `resource.Get()` to fetch the source res
 The following example demonstrates how to clone a Secret from the `default` namespace to the target namespace:
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: GeneratingPolicy
 metadata:
   name: generate-secret
@@ -159,7 +159,7 @@ This policy is triggered whenever a Namespace is created. It captures the trigge
 To clone multiple resources, you can use `resource.List()` to fetch a list of resources and then apply them in the target namespace. The following example demonstrates how to clone all Secrets from the `default` namespace:
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1alpha1
 kind: GeneratingPolicy
 metadata:
   name: generate-secrets
@@ -192,7 +192,7 @@ GeneratingPolicy supports forEach-style logic using CEL's list processing capabi
 The below policy creates a NetworkPolicy into a list of existing namespaces which is stored as a comma-separated string in a ConfigMap.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1alpha1
 kind: GeneratingPolicy
 metadata:
   name: generate-network-policy
@@ -233,7 +233,7 @@ Sometimes, you need to create uniquely named resources during a loop. By creatin
 The policy below creates a uniquely named NetworkPolicy (e.g., np-0, np-1) in each namespace defined in the ConfigMap.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: GeneratingPolicy
 metadata:
   name: generate-network-policy
@@ -290,7 +290,7 @@ There might be cases where you want to apply a filter to the list before generat
 The following policy combines filtering and indexing to generate resources for specific, pre-approved namespaces while maintaining their original index for naming consistency.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: GeneratingPolicy
 metadata:
   name: generate-network-policy
@@ -355,7 +355,7 @@ When cloning resources, you can also use looping to generate multiple resources 
 The following policy demonstrates how to clone a Secret for each namespace defined in a ConfigMap:
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: GeneratingPolicy
 metadata:
   name: generate-secrets
@@ -381,7 +381,7 @@ This policy is triggered whenever a ConfigMap is created. It captures the list o
 You can also clone multiple resources for each item in the list. The following example demonstrates how to clone all Secrets from the `default` namespace into each namespace defined in the ConfigMap:
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: GeneratingPolicy
 metadata:
   name: foreach-clone-list-sync-create
@@ -460,7 +460,7 @@ Both policy types have identical functionality and field structure. The only dif
 ### Example NamespacedGeneratingPolicy
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: NamespacedGeneratingPolicy
 metadata:
   name: clone-secret
@@ -494,7 +494,7 @@ To address this, you can set `evaluation.generateExisting.enabled` to true. This
 The following policy clones a secret to all new **and** existing namespaces:
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: GeneratingPolicy
 metadata:
   name: generate-secrets

--- a/src/content/docs/docs/policy-types/image-validating-policy.mdx
+++ b/src/content/docs/docs/policy-types/image-validating-policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: ImageValidatingPolicy
-excerpt: >-
+description: >-
   Verify container image signatures and attestations
 sidebar:
   order: 6
@@ -8,13 +8,13 @@ sidebar:
 
 import FeatureState from '../../../../components/FeatureState.astro'
 
-<FeatureState state="stable" version="v1.17" />
+<FeatureState state="beta" version="v1.16" />
 
 The Kyverno `ImageValidatingPolicy` type is a Kyverno policy type designed for verifying container image signatures and attestations.
 
 ## Additional Fields
 
-The `ImageValidatingPolicy` extends the [Kyverno ValidatingPolicy](/docs/policy-types/validating-policy) with the following additional fields for image verification features. A complete reference is provided in the [API specification](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/release-1.14/docs/user/crd/index.html#policies.kyverno.io/v1alpha1.ImageValidatingPolicy).
+The `ImageValidatingPolicy` extends the [Kyverno ValidatingPolicy](/docs/policy-types/validating-policy) with the following additional fields for image verification features. A complete reference is provided in the [API specification](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/release-1.16/docs/user/crd/index.html#policies.kyverno.io/v1beta1.ImageValidatingPolicy).
 
 ### images
 
@@ -23,7 +23,7 @@ When `Kubernetes` resources are evaluated images for pods and pod templates are 
 For example, this policy declaration will process the image specified in the `imageReference` field:
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: ImageValidatingPolicy
 metadata:
   name: sample
@@ -41,7 +41,7 @@ spec:
 The `spec.matchImageReferences` field defines rules for matching container images. It allows specifying glob patterns or CEL expressions that specify which images the policy should match.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: ImageValidatingPolicy
 metadata:
   name: check-images
@@ -59,7 +59,7 @@ The `attestors` field declares trusted signing authorities, such as keys or cert
 **Cosign attestors:** These use public keys, keyless signing, transparency logs, certificates, or TUF-based metadata for image validation.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: ImageValidatingPolicy
 metadata:
   name: check-images
@@ -150,7 +150,7 @@ spec:
 **Notary attestors:** These use certificates and optional Time Stamp Authority (TSA) certificates for image signature verification.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: ImageValidatingPolicy
 metadata:
   name: check-images
@@ -192,7 +192,7 @@ spec:
 The `attestations` field specifies additional metadata to validate.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: ImageValidatingPolicy
 metadata:
   name: check-images
@@ -228,7 +228,7 @@ spec:
 The `validationConfigurations` field defines settings for mutating image tags to digests, verifying that images are using digests, and enforcing image validation requirements across policies.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: ImageValidatingPolicy
 metadata:
   name: check-images
@@ -246,7 +246,7 @@ spec:
 Credentials specify the authentication information required to securely access and interact with a registry.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: ImageValidatingPolicy
 metadata:
   name: check-images
@@ -278,7 +278,7 @@ Both policy types have identical functionality and field structure. The only dif
 ### Example NamespacedImageValidatingPolicy
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: NamespacedImageValidatingPolicy
 metadata:
   name: verify-team-images
@@ -324,7 +324,7 @@ Kyverno provides specialized functions for verifying image signatures and attest
 The following policy demonstrates the use of these functions:
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: ImageValidatingPolicy
 metadata:
   name: check-images
@@ -379,7 +379,7 @@ This sample policy demonstrates how to verify container image signatures using C
 Kyverno supports the use of regular expressions in identities.subjectRegExp and identities.issuerRegExp fields when configuring keyless attestors
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: ImageValidatingPolicy
 metadata:
   name: require-vulnerability-scan
@@ -421,7 +421,7 @@ spec:
 :::note[Note]
 If your attestation names include special characters like `-`, access them using bracket syntax:
 
-```yaml
+```cel
 attestations["cosign-attes"]
 ```
 
@@ -433,7 +433,7 @@ Alternatively, prefer using camelCase or snake_case to avoid parsing issues in C
 This policy ensures that container images are signed with a specified Cosign public key before being admitted.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: ImageValidatingPolicy
 metadata:
   name: verify-image-ivpol

--- a/src/content/docs/docs/policy-types/mutating-policy.mdx
+++ b/src/content/docs/docs/policy-types/mutating-policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: MutatingPolicy
-excerpt: >-
+description: >-
   Mutate new or existing resources
 sidebar:
   order: 3
@@ -8,12 +8,12 @@ sidebar:
 
 import FeatureState from '../../../../components/FeatureState.astro'
 
-<FeatureState state="stable" version="v1.17" />
+<FeatureState state="beta" version="v1.16" />
 
 The Kyverno `MutatingPolicy` type extends the Kubernetes `MutatingAdmissionPolicy` type for complex mutation operations and other features required for Policy-as-Code. A `MutatingPolicy` is a superset of a `MutatingAdmissionPolicy` and contains additional fields for Kyverno specific features.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: MutatingPolicy
 metadata:
   name: add-label
@@ -59,14 +59,14 @@ The table below compares major features across the Kubernetes `MutatingAdmission
 
 ## Additional Fields
 
-The `MutatingPolicy` extends the [Kubernetes MutatingAdmissionPolicy](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/) with the following additional fields for Kyverno features. A complete reference is provided in the [API specification](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/main/docs/user/crd/index.html#policies.kyverno.io%2fv1alpha1).
+The `MutatingPolicy` extends the [Kubernetes MutatingAdmissionPolicy](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/) with the following additional fields for Kyverno features. A complete reference is provided in the [API specification](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/release-1.16/docs/user/crd/index.html#policies.kyverno.io%2fv1beta1).
 
 ### evaluation
 
 The `spec.evaluation` field defines how the policy is applied and how the payload is processed. It can be used to enable, or disable, admission request processing and existing resource mutation for a policy.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: MutatingPolicy
 metadata:
   name: sample
@@ -83,14 +83,14 @@ spec:
 
 - **`mutateExisting.enabled`**: When set to `true`, the policy is applied to existing resources in the cluster through background processing. This allows you to mutate resources that already exist without requiring them to be recreated or updated.
 
-Refer to the [API Reference](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/main/docs/user/crd/index.html#policies.kyverno.io/v1alpha1.EvaluationConfiguration) for details.
+Refer to the [API Reference](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/release-1.16/docs/user/crd/index.html#policies.kyverno.io/v1beta1.EvaluationConfiguration) for details.
 
 ### webhookConfiguration
 
 The `spec.webhookConfiguration` field defines properties used to manage the Kyverno admission controller webhook settings.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: MutatingPolicy
 metadata:
   name: add-labels
@@ -102,7 +102,7 @@ spec:
 
 In the policy above, `webhookConfiguration.timeoutSeconds` is set to `15`, which defines how long the admission request waits for policy evaluation. The default is `10` seconds, and the allowed range is `1` to `30` seconds. After this timeout, the request will fail or ignore the result based on the failure policy. Kyverno reflects this setting in the generated `MutatingWebhookConfiguration`.
 
-Refer to the [API Reference](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/main/docs/user/crd/index.html#policies.kyverno.io/v1alpha1.WebhookConfiguration) for details.
+Refer to the [API Reference](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/release-1.16/docs/user/crd/index.html#policies.kyverno.io/v1beta1.WebhookConfiguration) for details.
 
 ### autogen
 
@@ -111,7 +111,7 @@ The `spec.autogen` field defines policy auto-generation behaviors, to automatica
 Here is an example of generating policies for deployments, jobs, cronjobs, and statefulsets and also generating a `MutatingAdmissionPolicy` from the `MutatingPolicy` declaration:
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: MutatingPolicy
 metadata:
   name: add-default-labels
@@ -129,7 +129,7 @@ spec:
 
 Generating a `MutatingAdmissionPolicy` from a `MutatingPolicy` provides the benefits of faster and more resilient execution during admission controls while leveraging all features of Kyverno.
 
-Refer to the [API Reference](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/main/docs/user/crd/index.html#policies.kyverno.io/v1alpha1.AutogenConfiguration) for details.
+Refer to the [API Reference](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/release-1.16/docs/user/crd/index.html#policies.kyverno.io/v1beta1.AutogenConfiguration) for details.
 
 ## Policy Scope
 
@@ -143,7 +143,7 @@ Both policy types have identical functionality and field structure. The only dif
 ### Example NamespacedMutatingPolicy
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: NamespacedMutatingPolicy
 metadata:
   name: add-labels
@@ -182,7 +182,7 @@ ApplyConfiguration patches use a merge-style approach, written as CEL expression
 ### Basic ApplyConfiguration
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: MutatingPolicy
 metadata:
   name: add-service-account
@@ -209,7 +209,7 @@ spec:
 ### Conditional ApplyConfiguration
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: MutatingPolicy
 metadata:
   name: conditional-labels
@@ -244,7 +244,7 @@ JSONPatch provides fine-grained control over mutations using RFC 6902 JSON Patch
 ### Basic JSONPatch
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: MutatingPolicy
 metadata:
   name: add-labels-jsonpatch
@@ -283,7 +283,7 @@ spec:
 ### Multiple JSONPatch Operations
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: MutatingPolicy
 metadata:
   name: complex-jsonpatch
@@ -320,7 +320,7 @@ spec:
 ### Conditional JSONPatch with Escape
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: MutatingPolicy
 metadata:
   name: escape-jsonpatch
@@ -355,7 +355,7 @@ Kyverno supports looping through elements within resources using CEL functions l
 ### Iterating Through Containers
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: MutatingPolicy
 metadata:
   name: foreach
@@ -387,7 +387,7 @@ This example uses CEL's `map()` function to iterate through all containers in a 
 ### Conditional Iteration with Filter
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: MutatingPolicy
 metadata:
   name: foreach-conditional
@@ -429,7 +429,7 @@ MutatingPolicy supports background processing to mutate existing resources in th
 When the trigger and target are the same resource type, the policy will mutate ALL existing resources of that type when a trigger occurs:
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: MutatingPolicy
 metadata:
   name: same-trigger-target
@@ -468,7 +468,7 @@ This means if you have 10 existing namespaces and create a new one, all 11 names
 You can specify different trigger and target resources using `targetMatchConstraints`. When a trigger occurs, Kyverno will mutate ALL existing resources that match the target criteria:
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: MutatingPolicy
 metadata:
   name: different-trigger-target
@@ -521,7 +521,7 @@ The order of mutations is important when multiple mutations are applied. Kyverno
 When multiple mutations are defined within the same policy, they are processed in order. This allows you to create mutations that depend on the results of previous mutations:
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: MutatingPolicy
 metadata:
   name: simple-database-policy
@@ -572,7 +572,7 @@ The mutations must be ordered from top to bottom in the order of their dependenc
 The `reinvocationPolicy` controls whether mutations are reapplied when earlier mutations modify the object:
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: MutatingPolicy
 metadata:
   name: reinvocation-example

--- a/src/content/docs/docs/policy-types/overview.md
+++ b/src/content/docs/docs/policy-types/overview.md
@@ -1,36 +1,76 @@
 ---
 title: Overview
-excerpt: >-
-  Kyverno Policy Types
+description: >-
+  Kyverno Policy Types - CEL-based and Traditional
 sidebar:
   order: 1
 ---
 
-Kyverno offers multiple policy types decribed below. Kyverno's mission is to be the best policy engine for Kubernetes, and allow applying Kubernetes style policies everywhere incuding outside of Kubernetes.
+Kyverno offers multiple policy types to secure, automate, and operate your Kubernetes infrastructure.
 
-As Kubernetes has evolved, Kyverno has also evolved its APIs. Kyverno initially supported JMESPath as a fast and effecient JSON processing language. Since 2022, Kubernetes has added [extensive support for Common Expression Language (CEL)](https://kubernetes.io/docs/reference/using-api/cel/). Hence, Kyverno has also evolved to fully support CEL. This shift allows Kyverno to maintain native compatibility and reduces the cognitive load for platform teams as there is one less thing to learn!
+## CEL-based Policies (Recommended)
 
-The new CEL based Kyverno [ValidatingPolicy](/docs/policy-types/validating-policy) and [ImageValidatingPolicy](/docs/policy-types/image-validating-policy) types were introduced in v1.14 (April 2025), and [MutatingPolicy](/docs/policy-types/mutating-policy), [GeneratingPolicy](/docs/policy-types/generating-policy), and [DeletingPolicy](/docs/policy-types/deleting-policy) were added in v1.15 (July 2025).
+**CEL-based policies** (v1beta1) use the Common Expression Language (CEL) and are aligned with Kubernetes' native ValidatingAdmissionPolicy.
 
-## Policy Types
+### Advantages
 
-| Policy Type                                                         | Description                                                                | API Version              | Status             |
-| ------------------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------ | ------------------ |
-| [ValidatingPolicy](/docs/policy-types/validating-policy)            | Validate Kubernetes resources or JSON payloads                             | `policies.kyverno.io/v1` | Stable (v1.17)     |
-| [MutatingPolicy](/docs/policy-types/mutating-policy)                | Mutate new or existing resources                                           | `policies.kyverno.io/v1` | Stable (v1.17)     |
-| [GeneratingPolicy](/docs/policy-types/generating-policy)            | Create or clone resources based on flexible triggers                       | `policies.kyverno.io/v1` | Stable (v1.17)     |
-| [DeletingPolicy](/docs/policy-types/deleting-policy)                | Deletes matching resources based on a schedule                             | `policies.kyverno.io/v1` | Stable (v1.17)     |
-| [ImageValidatingPolicy](/docs/policy-types/image-validating-policy) | Verify container image signatures and attestations                         | `policies.kyverno.io/v1` | Stable (v1.17)     |
-| [ClusterPolicy](/docs/policy-types/cluster-policy/overview)         | Legacy policy type with validate, mutate, generate, and verifyImages rules | `kyverno.io/v1`          | Deprecated (v1.17) |
-| [CleanupPolicy](/docs/policy-types/cleanup-policy)                  | Legacy policy type that deletes matching resources based on a schedule     | `kyverno.io/v2`          | Deprecated (v1.17) |
+- **Performance**: Faster latency and reduced CPU usage.
+- **K8s Native**: Generates native ValidatingAdmissionPolicy and MutatingAdmissionPolicy.
+- **Expressiveness**: Flexible logic using CEL.
 
-## Deprecation Schedule for Legacy Types
+### Policy Types
 
-The `ClusterPolicy` and `CleanupPolicy` will be suported for multiple releases, as detailed below:
+| Type | Purpose |
+|------|---------|
+| [ValidatingPolicy](/docs/policy-types/validating-policy) | Validate resources or JSON payloads |
+| [MutatingPolicy](/docs/policy-types/mutating-policy) | Mutate new or existing resources |
+| [GeneratingPolicy](/docs/policy-types/generating-policy) | Create or clone resources |
+| [DeletingPolicy](/docs/policy-types/deleting-policy) | Delete resources on a schedule |
+| [ImageValidatingPolicy](/docs/policy-types/image-validating-policy) | Verify container image signatures |
 
-| Release | Date (estimated) | Status                 |
-| ------- | ---------------- | ---------------------- |
-| v1.17   | Jan 2026         | Marked for deprecation |
-| v1.18   | Apr 2026         | Critical fixes only    |
-| v1.19   | Jul 2026         | Critical fixes only    |
-| v1.20   | Oct 2026         | Planned for removal    |
+All types support both cluster-scoped (e.g., `ValidatingPolicy`) and namespace-scoped (e.g., `NamespacedValidatingPolicy`) variants.
+
+### Roadmap
+
+- **v1.14**: Initial alpha (Validating/ImageValidating)
+- **v1.15**: Alpha extension (Mutating/Generating/Deleting)
+- **v1.16**: Beta promotion (v1beta1)
+- **v1.17**: v1 API (Planned)
+
+## Traditional Policies (Legacy)
+
+**ClusterPolicy/Policy** resources use YAML patterns and JMESPath. They remain fully supported but are recommended primarily for existing deployments or simple pattern matching.
+
+:::note[Migration]
+Existing policies do not need immediate migration. For new policies, we recommend the CEL-based format. See the [Migration Guide](/docs/migration/traditional-to-cel).
+:::
+
+| Task | Traditional Policy Field |
+|------|--------------------------|
+| Validate | `validate` rule |
+| Mutate | `mutate` rule |
+| Generate | `generate` rule |
+| Verify Image | `verifyImages` rule |
+| Cleanup | `cleanup` policy |
+
+Reference: [ClusterPolicy Overview](/docs/policy-types/cluster-policy/overview).
+
+## Selection Guide
+
+### Use CEL-based Policies for:
+- New deployments
+- Performance-sensitive environments
+- Complex validation logic
+- Native Kubernetes policy generation
+- Non-Kubernetes payloads (Terraform, JSON)
+
+### Use Traditional Policies for:
+- Existing stable policies
+- Simple pattern matching
+- Teams preferring YAML-only syntax
+
+## Quick Start
+
+1. **[Getting Started with CEL Policies](/docs/cel/getting-started)** - Basics of using CEL in Kyverno
+2. **[CEL vs Traditional Policies](/docs/cel/cel-vs-traditional)** - Comparison guide
+3. **[Sample Policies](/policies)** - Browse policy examples

--- a/src/content/docs/docs/policy-types/validating-policy.mdx
+++ b/src/content/docs/docs/policy-types/validating-policy.mdx
@@ -1,18 +1,18 @@
 ---
 title: ValidatingPolicy
-excerpt: Validate Kubernetes resources or JSON payloads
+description: Validate Kubernetes resources or JSON payloads
 sidebar:
   order: 2
 ---
 
 import FeatureState from '../../../../components/FeatureState.astro'
 
-<FeatureState state="stable" version="v1.17" />
+<FeatureState state="beta" version="v1.16" />
 
 The Kyverno `ValidatingPolicy` type extends the Kubernetes `ValidatingAdmissionPolicy` type for complex policy evaluations and other features required for Policy-as-Code. A `ValidatingPolicy` is a superset of a `ValidatingAdmissionPolicy` and contains additional fields for Kyverno specific features.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: ValidatingPolicy
 metadata:
   name: check-labels
@@ -51,14 +51,14 @@ The table below compares major features across the Kubernetes `ValidatingAdmissi
 
 ## Additional Fields
 
-The `ValidatingPolicy` extends the [Kubernetes ValidatingAdmissionPolicy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) with the following additional fields for Kyverno features. A complete reference is provided in the [API specification](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/release-1.14/docs/user/crd/index.html#policies.kyverno.io/v1alpha1.ValidatingPolicy).
+The `ValidatingPolicy` extends the [Kubernetes ValidatingAdmissionPolicy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) with the following additional fields for Kyverno features. A complete reference is provided in the [API specification](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/release-1.16/docs/user/crd/index.html#policies.kyverno.io/v1beta1.ValidatingPolicy).
 
 ### evaluation
 
 The `spec.evaluation` field defines how the policy is applied and how the payload is processed. It can be used to enable, or disable, admission request processing and background processing for a policy. It is also used to manage whether the payload is processed as JSON or a Kubernetes resource.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: ValidatingPolicy
 metadata:
   name: sample
@@ -74,14 +74,14 @@ spec:
 
 The `mode` can be set to `JSON` for non-Kubernetes payloads.
 
-Refer to the [API Reference](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/release-1.14/docs/user/crd/index.html#policies.kyverno.io/v1alpha1.EvaluationConfiguration) for details.
+Refer to the [API Reference](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/release-1.16/docs/user/crd/index.html#policies.kyverno.io/v1beta1.EvaluationConfiguration) for details.
 
 ### webhookConfiguration
 
 The `spec.webhookConfiguration` field defines properties used to manage the Kyverno admission controller webhook settings.
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: ValidatingPolicy
 metadata:
   name: check-deployment-labels
@@ -93,7 +93,7 @@ spec:
 
 In the policy above, `webhookConfiguration.timeoutSeconds` is set to `15`, which defines how long the admission request waits for policy evaluation. The default is `10` seconds, and the allowed range is `1` to `30` seconds. After this timeout, the request may fail or ignore the result based on the failure policy. Kyverno reflects this setting in the generated `ValidatingWebhookConfiguration`.
 
-Refer to the [API Reference](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/release-1.14/docs/user/crd/index.html#policies.kyverno.io/v1alpha1.WebhookConfiguration) for details.
+Refer to the [API Reference](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/release-1.16/docs/user/crd/index.html#policies.kyverno.io/v1beta1.WebhookConfiguration) for details.
 
 ### autogen
 
@@ -102,7 +102,7 @@ The `spec.autogen` field defines policy auto-generation behaviors, to automatica
 Here is an example of generating policies for deployments, jobs, cronjobs, and statefulsets and also generating a `ValidatingAdmissionPolicy` from the `ValidatingPolicy` declaration:
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: ValidatingPolicy
 metadata:
   name: disallow-capabilities
@@ -120,7 +120,7 @@ spec:
 
 Generating a `ValidatingAdmissionPolicy` from a `ValidatingPolicy` provides the benefits of faster and more resilient execution during admission controls while leveraging all features of Kyverno.
 
-Refer to the [API Reference](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/release-1.14/docs/user/crd/index.html#policies.kyverno.io/v1alpha1.AutogenConfiguration) for details.
+Refer to the [API Reference](https://htmlpreview.github.io/?https://github.com/kyverno/kyverno/blob/release-1.16/docs/user/crd/index.html#policies.kyverno.io/v1beta1.AutogenConfiguration) for details.
 
 ## Policy Scope
 
@@ -134,7 +134,7 @@ Both policy types have identical functionality and field structure. The only dif
 ### Example NamespacedValidatingPolicy
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: NamespacedValidatingPolicy
 metadata:
   name: check-deployment-replicas
@@ -168,7 +168,7 @@ Policies are applied cluster-wide by default. However, there may be times when a
 The Kyverno ValidatingPolicy can be applied to any JSON payload. Here is an example of a policy that can be applied to a Terraform plan, and ensures that EKS clusters do not expose a public endpoint:
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: ValidatingPolicy
 metadata:
   name: check-public-endpoint
@@ -226,7 +226,7 @@ This is useful for adding metadata such as severity, team ownership, or any reso
 **Example Policy:**
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: ValidatingPolicy
 metadata:
   name: check-deployment-labels
@@ -264,7 +264,7 @@ If the expression fails or produces an invalid string (empty, whitespace-only, o
 **Example Policy:**
 
 ```yaml
-apiVersion: policies.kyverno.io/v1
+apiVersion: policies.kyverno.io/v1beta1
 kind: ValidatingPolicy
 metadata:
   name: check-deployment-labels


### PR DESCRIPTION
## Description

This PR adds two new guides to help users understand and adopt CEL-based policies:

- **CEL Getting Started** - A beginner-friendly introduction to writing CEL policies
- **CEL vs Traditional Policies** - Side-by-side comparisons showing the differences

## Related Issue

Replaces #1821 (closed)
Related to kyverno/kyverno#14726 (LFX Option 2: CEL-Focused Mentorship)

## Proposed Changes

- Added `docs/guides/cel-getting-started.md` 
- Added `docs/guides/cel-vs-traditional.md`
- Updated sidebar navigation to include new guides
- All examples use the stable `v1` API

## Checklist

- [x] Documentation follows the style guide
- [x] Build passes locally