### PR TITLE
Update title from 'Kubernetes' to 'Kyverno'  on the Quick Start doc page

### DIFF
--- a/src/content/docs/docs/introduction/quick-start.md
+++ b/src/content/docs/docs/introduction/quick-start.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Quick Start
+title: Kyverno Quick Start
 linkTitle: Quick Start Guides
 sidebar:
   order: 20


### PR DESCRIPTION


## Proposed Changes

This PR fixes a typo on the Quick Start page, updating ‘Kubernetes Quick Start’ to ‘Kyverno Quick Start.


## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
