### PR TITLE
fix: corrected indentation in mutatingpolicy/#different-trigger-and-t…

### DIFF
--- a/src/content/docs/docs/policy-types/mutating-policy.mdx
+++ b/src/content/docs/docs/policy-types/mutating-policy.mdx
@@ -484,9 +484,9 @@ spec:
         resources: ['namespaces']
         resourceNames: ['test-namespace']
   targetMatchConstraints:
-  namespaceSelector:
-    matchLabels:
-      test: 'enabled'
+    namespaceSelector:
+      matchLabels:
+        test: 'enabled'
     resourceRules:
       - apiGroups: ['']
         apiVersions: ['v1']


### PR DESCRIPTION
## Related issue
#1896

## Proposed Changes
Fixed incorrect indentation of the namespaceSelector field under 
targetMatchConstraints in the MutatingPolicy example. The field was 
at the same level as targetMatchConstraints instead of being nested 
inside it, which did not reflect the correct YAML structure.

## Checklist
- [x] I have read the contributing guidelines.
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.