### PR TITLE
docs: document params.originalRequest for MutatingPolicy mutate existing resources

### DIFF
--- a/src/content/docs/docs/policy-types/mutating-policy.mdx
+++ b/src/content/docs/docs/policy-types/mutating-policy.mdx
@@ -512,6 +512,82 @@ In this example:
 
 This means if you have 5 ConfigMaps in matching namespaces and update the trigger namespace, all 5 ConfigMaps will be mutated.
 
+### Accessing the Original Request
+
+When using `targetMatchConstraints`, the `object` and `oldObject` variables in the CEL context refer to the **target** resource being mutated, not the resource that triggered the original admission request. To access the triggering resource's data, Kyverno provides the `params.originalRequest` variable, which contains:
+
+- **`params.originalRequest.object`**: The object from the original admission request that triggered the mutation (the trigger resource).
+- **`params.originalRequest.oldObject`**: The old object from the original admission request (available on UPDATE operations).
+
+This is useful when your policy needs to:
+1. Filter execution based on properties of the triggering resource (via `matchConditions`)
+2. Extract data from the triggering resource for use in mutations (via `variables`)
+
+The following example demonstrates a policy where a `ConfigMap` update triggers mutations on `ScaledObject` resources. The policy reads the Prometheus server address from the triggering `ConfigMap` and applies it to matching `ScaledObject` targets:
+
+```yaml
+apiVersion: policies.kyverno.io/v1
+kind: MutatingPolicy
+metadata:
+  name: keda-prometheus-serveraddress-configmap
+spec:
+  evaluation:
+    mutateExisting:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["configmaps"]
+        operations: ["CREATE", "UPDATE"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: observability
+  matchConditions:
+    # Only trigger when the specific ConfigMap is modified
+    - name: is-target-configmap
+      expression: >-
+        params.originalRequest.object.metadata.name == "keda-prometheus-serveraddress"
+  targetMatchConstraints:
+    resourceRules:
+      - apiGroups: ["keda.sh"]
+        apiVersions: ["v1alpha1"]
+        resources: ["scaledobjects"]
+  variables:
+    - name: serverAddress
+      expression: >-
+        params.originalRequest.object.data["main"]
+  mutations:
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: >-
+          has(object.metadata.annotations)
+          && object.metadata.annotations.exists(k,
+            k == "prometheus.keda.sh/use-central-serveraddress"
+          )
+          && object.metadata.annotations["prometheus.keda.sh/use-central-serveraddress"] == "true"
+          ? object.spec.triggers.filter(e,
+              has(e.type) && e.type == "prometheus"
+            ).map(e,
+              JSONPatch{
+                op: "replace",
+                path: "/spec/triggers/" + string(object.spec.triggers.indexOf(e)) + "/metadata/serverAddress",
+                value: string(variables.serverAddress)
+              }
+            )
+          : []
+```
+
+In this example:
+
+- **Trigger**: A `ConfigMap` named `keda-prometheus-serveraddress` in the `observability` namespace is created or updated.
+- **`params.originalRequest.object`** is used in `matchConditions` to filter by the trigger ConfigMap name, and in `variables` to extract the server address value.
+- **Target**: All existing `ScaledObject` resources with the annotation `prometheus.keda.sh/use-central-serveraddress: "true"` are mutated to update their Prometheus trigger `serverAddress`.
+
+:::note
+When a policy is evaluated during a direct admission request (without `targetMatchConstraints`), `params.originalRequest.object` and `params.originalRequest.oldObject` will contain the same data as `object` and `oldObject` respectively.
+:::
+
 ## Mutate Ordering
 
 The order of mutations is important when multiple mutations are applied. Kyverno processes mutations in the order they appear in the policy. However, **the order is not guaranteed across multiple MutatingPolicies** - if multiple policies apply to the same resource, their execution order is not deterministic.


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

Issue https://github.com/kyverno/kyverno/issues/15610, PR https://github.com/kyverno/kyverno/pull/15612

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

Documents the new `params.originalRequest` variable available in `MutatingPolicy` when using `targetMatchConstraints` (mutate existing resources). This variable provides access to the original admission request's `object` and `oldObject` from within the CEL evaluation context, enabling policies to reference the triggering resource when the trigger and target are different resource types.

Added a new "Accessing the Original Request" subsection under "Mutating Existing Resources" > "Different Trigger and Target" covering:

- Description of `params.originalRequest.object` and `params.originalRequest.oldObject`
- Use cases: filtering by trigger properties in `matchConditions` and extracting trigger data in `variables`
- Complete example policy (KEDA ScaledObject mutated by ConfigMap trigger)
- Note about behavior during direct admission requests

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
