### PR TITLE
fix: validatingPolicy auditAnnotation has incorrect valueExpression

### DIFF
--- a/src/content/docs/docs/policy-types/validating-policy.mdx
+++ b/src/content/docs/docs/policy-types/validating-policy.mdx
@@ -234,7 +234,7 @@ metadata:
 spec:
   auditAnnotations:
     - key: team
-      valueExpression: 'platform'
+      valueExpression: "'platform'"
   matchConstraints:
     resourceRules:
       - apiGroups: [apps]


### PR DESCRIPTION
AuditAnnotation in ValidatingPolicy is k8s admissionregistration audit annotation. The value expression must evaluate to either a string or null value. https://github.com/kubernetes/kubernetes/blob/v1.35.3/pkg/apis/admissionregistration/types.go#L378
Current example is incorrect and results in error when trying to test it on playground:
```
ServerError: failed to compile policy check-deployment-labels ([: Internal error: validating policy compiler 2.0 error: failed to compile policy, spec.auditAnnotations[0].valueExpression: Invalid value: "platform": ERROR: 
:1:1: undeclared reference to 'platform' (in container '') | platform | ^])
```
This pr fixes it by wrapping ```platform``` to a valid cel expression.