### PR TITLE
fix: correct CEL syntax errors in mutating-policy foreach examples

### DIFF
--- a/src/content/docs/docs/policy-types/mutating-policy.mdx
+++ b/src/content/docs/docs/policy-types/mutating-policy.mdx
@@ -378,7 +378,7 @@ spec:
                 securityContext: Object.spec.containers.securityContext{
                   allowPrivilegeEscalation: false
                 }
-              }
+              })
             }
           }
 ```
@@ -393,12 +393,12 @@ kind: MutatingPolicy
 metadata:
   name: foreach-conditional
 spec:
-matchConstraints:
-  resourceRules:
-    - apiGroups: ['']
-      apiVersions: ['v1']
-      resources: ['pods']
-      operations: ['CREATE', 'UPDATE']
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ['']
+        apiVersions: ['v1']
+        resources: ['pods']
+        operations: ['CREATE', 'UPDATE']
   mutations:
     - patchType: JSONPatch
       jsonPatch:


### PR DESCRIPTION
## Summary

Two syntax bugs in the `MutatingPolicy` CEL expression examples under [Looping with CEL Functions](https://kyverno.io/docs/policy-types/mutating-policy/#iterating-through-containers):

- **Iterating Through Containers**: the `map()` call was missing its closing `)`. The CEL expression as written fails to compile with `Syntax error: missing ')' at '}'`. The fix adds `)` after the closing `}` of the container object literal so the call is `map(container, Object.spec.containers{...})`.
- **Conditional Iteration with Filter**: `matchConstraints` and `resourceRules` were dedented out of `spec:`, making the YAML structurally invalid. The fix restores the correct two-space indentation under `spec:`.

## Verification

Tested the fixed `foreach` policy with `kyverno apply` (v1.17.0) against a two-container Pod:

```
$ kyverno apply policy.yaml --resource pod.yaml
policy foreach applied to default/Pod/test-pod:
spec:
  containers:
  - name: nginx
    securityContext:
      allowPrivilegeEscalation: false
  - name: sidecar
    securityContext:
      allowPrivilegeEscalation: false
Mutation has been applied successfully.
```

## Test plan

- [x] `kyverno apply` with the fixed policy succeeds and applies `allowPrivilegeEscalation: false` to all containers
- [x] The original (unfixed) policy produces `Syntax error: missing ')' at '}'`