### PR TITLE
feat: add New Policies Only filter toggle to policy browser

### DIFF
--- a/src/components/policy/PolicyBrowser.jsx
+++ b/src/components/policy/PolicyBrowser.jsx
@@ -10,6 +10,7 @@ import {
   formatCategoryLabel,
   formatSeverityLabel,
   getSeverityOrder,
+  isPolicyNew,
 } from './utils'
 import { useEffect, useMemo, useState } from 'react'
 
@@ -24,6 +25,7 @@ export const PolicyBrowser = ({ policies }) => {
   const [selectedTypes, setSelectedTypes] = useState([])
   const [activeCategoryButton, setActiveCategoryButton] = useState('all')
   const [currentPage, setCurrentPage] = useState(1)
+  const [showNewOnly, setShowNewOnly] = useState(false)
   const itemsPerPage = 24
 
   // Helper function to check if a policy matches filters (excluding a specific filter type)
@@ -86,13 +88,16 @@ export const PolicyBrowser = ({ policies }) => {
       selectedTypes.length === 0 ||
       (policy.data.type && selectedTypes.includes(policy.data.type))
 
+    const matchesNew = !showNewOnly || isPolicyNew(policy.data.createdAt)
+
     return (
       matchesSearch &&
       matchesCategory &&
       matchesSeverity &&
       matchesResource &&
       matchesTag &&
-      matchesType
+      matchesType &&
+      matchesNew
     )
   }
 
@@ -127,6 +132,7 @@ export const PolicyBrowser = ({ policies }) => {
       selectedResources,
       selectedTags,
       selectedTypes,
+      showNewOnly,
     ],
   )
 
@@ -139,6 +145,7 @@ export const PolicyBrowser = ({ policies }) => {
       selectedResources,
       selectedTags,
       selectedTypes,
+      showNewOnly,
     ],
   )
 
@@ -151,6 +158,7 @@ export const PolicyBrowser = ({ policies }) => {
       selectedResources,
       selectedTags,
       selectedTypes,
+      showNewOnly,
     ],
   )
 
@@ -163,6 +171,7 @@ export const PolicyBrowser = ({ policies }) => {
       selectedSeverities,
       selectedTags,
       selectedTypes,
+      showNewOnly,
     ],
   )
 
@@ -175,6 +184,7 @@ export const PolicyBrowser = ({ policies }) => {
       selectedSeverities,
       selectedResources,
       selectedTypes,
+      showNewOnly,
     ],
   )
 
@@ -216,6 +226,7 @@ export const PolicyBrowser = ({ policies }) => {
     selectedResources,
     selectedTags,
     selectedTypes,
+    showNewOnly,
   ])
 
   // Reset to page 1 when filters change
@@ -228,6 +239,7 @@ export const PolicyBrowser = ({ policies }) => {
     selectedResources,
     selectedTags,
     selectedTypes,
+    showNewOnly,
   ])
 
   // Calculate pagination
@@ -400,6 +412,14 @@ export const PolicyBrowser = ({ policies }) => {
         ariaLabel: `Remove ${tag} filter`,
       })
     })
+    if (showNewOnly) {
+      filters.push({
+        type: 'new',
+        label: 'New Policies Only',
+        onRemove: () => setShowNewOnly(false),
+        ariaLabel: 'Remove new policies filter',
+      })
+    }
     return filters
   }, [
     searchQuery,
@@ -408,9 +428,15 @@ export const PolicyBrowser = ({ policies }) => {
     selectedTypes,
     selectedResources,
     selectedTags,
+    showNewOnly,
   ])
 
   const hasActiveFilters = activeFilters.length > 0
+
+  const newPoliciesCount = useMemo(
+    () => policies.filter((p) => isPolicyNew(p.data.createdAt)).length,
+    [policies],
+  )
 
   const clearAllFilters = () => {
     setSearchQuery('')
@@ -419,6 +445,7 @@ export const PolicyBrowser = ({ policies }) => {
     setSelectedResources([])
     setSelectedTags([])
     setSelectedTypes([])
+    setShowNewOnly(false)
     setActiveCategoryButton('all')
   }
 
@@ -503,6 +530,29 @@ export const PolicyBrowser = ({ policies }) => {
       <div className="flex flex-col lg:grid lg:grid-cols-[280px_1fr] gap-4 lg:gap-8">
         {/* Filter Sidebar */}
         <aside className="static lg:sticky lg:top-8 h-fit space-y-4">
+          {/* New Policies Toggle */}
+          <button
+            type="button"
+            onClick={() => setShowNewOnly((prev) => !prev)}
+            className={`w-full flex items-center justify-between px-4 sm:px-6 py-4 backdrop-blur-sm border rounded-2xl shadow-lg text-xs uppercase tracking-widest font-bold transition-all ${
+              showNewOnly
+                ? 'bg-purple-950/20 border-purple-900/50 text-purple-400'
+                : 'bg-dark-50/80 border-stroke/50 text-theme-tertiary hover:text-purple-400 hover:border-purple-900/50'
+            }`}
+            aria-pressed={showNewOnly}
+          >
+            <span>New Policies</span>
+            <span
+              className={`px-2 py-0.5 rounded-md text-xs font-semibold ${
+                showNewOnly
+                  ? 'bg-purple-950/50 text-purple-300'
+                  : 'bg-stroke/50 text-theme-tertiary'
+              }`}
+            >
+              {newPoliciesCount}
+            </span>
+          </button>
+
           <FilterSection
             title="Policy Kind"
             items={Object.entries(typeCounts)}


### PR DESCRIPTION

The policy library already badges recently added policies, but finding them meant scrolling through 640+ cards hunting for purple dots. This adds a **New Policies** toggle to the filter sidebar that narrows the grid to policies from the last 90 days (~166 currently).

It plays nicely with existing filters (severity, category, tags), shows up as a removable chip in the active filters bar, and clears with "Clear all". Wired up the existing `isPolicyNew` utility from `utils.ts` , it was already powering the badges, just never hooked into the browser itself.

Before 

https://github.com/user-attachments/assets/87a7b880-ac8f-4dcd-add5-b007f0615c75

After 

https://github.com/user-attachments/assets/7419c119-1da7-45af-b981-615b5fcfca58

