### PR TITLE
fix: docker registry name mismatch

### DIFF
--- a/src/content/docs/docs/policy-types/cel-libraries.mdx
+++ b/src/content/docs/docs/policy-types/cel-libraries.mdx
@@ -311,7 +311,7 @@ The **Image library** offers functions to parse and analyze image references. It
 | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | `image("nginx:latest")`                                                                     | Convert an image string into an image object (must be used before calling any image methods) |
 | `isImage("nginx:latest")`                                                                   | Check if the string is a valid image                                                         |
-| `image("nginx:latest").registry()`                                                          | Get the image registry (e.g., `docker.io`)                                                   |
+| `image("nginx:latest").registry()`                                                          | Get the image registry (e.g., `index.docker.io`)                                             |
 | `image("nginx:latest").repository()`                                                        | Get the image repository path (e.g., `library/nginx`)                                        |
 | `image("nginx:latest").identifier()`                                                        | Get the image identifier (e.g., tag or digest part)                                          |
 | `image("nginx:latest").tag()`                                                               | Get the tag portion of the image (e.g., `latest`)                                            |


### PR DESCRIPTION
## Related issue

* https://github.com/google/go-containerregistry/issues/68 (`go-containerregistry` issue that mentions the change)

## Proposed Changes

The example given for the registry for `nginx:latest` when using the CEL library is inaccurate, as it's been changed to `index.docker.io` a while ago:

https://github.com/google/go-containerregistry/blob/7ab219a508a221e20b12b556cc5789be61a149b4/pkg/name/registry.go#L134-L138

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [X] I have inspected the website preview for accuracy.
- [X] I have signed off my issue.
