### PR TITLE
fix: remove duplicate navigation links in mobile menu

### DIFF
--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -87,8 +87,7 @@ export const TopNav = () => {
             className="fixed right-0 z-20 bg-dark-50 w-full p-12 flex 
                     flex-col justify-center items-center space-y-6 lg:hidden mt-3"
           >
-            <TopNavLinks links={navItemsOnsite} handleScroll={handleScroll} />
-            <TopNavLinks links={navItemsExternal} />
+            <TopNavLinks links={navItemsExternal} handleScroll={handleScroll} />
             <div className="xl:hidden flex flex-col space-y-4 items-center">
               <VersionDropdown />
               <div className="flex space-x-2">


### PR DESCRIPTION


## Related issue
Fixes:  #2011 

This PR resolves a UI bug where navigation links were rendered twice within the mobile overlay. The duplication resulted from redundant component mounting in the mobile view logic.

## Proposed Changes

- Removed the duplicate menu by deleting the extra set of links so they only show once.
- Fixed the click behavior to ensure the links properly close the menu and scroll the page.
- Simplified the code so the mobile menu uses just one list of links instead of two.

Before image
<img width="300" height="280" alt="IMG-20260513-WA0006(1)" src="https://github.com/user-attachments/assets/9e5ae51e-f33f-475a-ba3e-a54ba5de4739" />
After image
<img width="300" height="330" alt="IMG-20260513-WA0007" src="https://github.com/user-attachments/assets/965dc435-2ad5-47ba-8eed-8178c48e6678" />


## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
