### PR TITLE
feat: add automated PR labeler workflow 

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,71 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/content/docs/**/*.{md,mdx}'
+          - 'src/content/policies/**/*.md'
+          - 'content/**/*.md'
+          - 'README.md'
+          - 'CONTRIBUTING.md'
+          - 'DEVELOPMENT.md'
+          - 'OWNERS.md'
+
+blog:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/content/blog/**/*'
+
+website-redesign:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/components/**/*.{astro,css,js,jsx,ts,tsx}'
+          - 'src/layouts/**/*.astro'
+          - 'src/sections/**/*.{astro,css,js,jsx,ts,tsx}'
+          - 'src/styles/**/*.css'
+          - 'public/assets/**/*'
+
+github_actions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**/*.{yml,yaml}'
+          - '.github/actions/**/*.{yml,yaml}'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'package.json'
+          - 'package-lock.json'
+          - '.github/dependabot.yml'
+
+config:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'astro.config.mjs'
+          - 'markdoc.config.mjs'
+          - 'src/content.config.ts'
+          - 'netlify.toml'
+          - 'tsconfig.json'
+          - 'lychee.toml'
+
+javascript:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/constants/**/*.{js,ts}'
+          - 'src/hooks/**/*.{js,jsx,ts,tsx}'
+          - 'src/utils/**/*.{js,ts}'
+          - 'scripts/**/*.{js,ts,mjs,cjs}'
+
+go:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.go'
+          - 'go.mod'
+          - 'go.sum'
+
+webhook:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/content/docs/**/admission-controllers.md'
+          - 'src/content/docs/**/validating-policy.mdx'
+          - 'src/content/docs/**/mutating-policy.mdx'
+          - 'src/content/docs/**/image-validating-policy.mdx'
+          - 'src/content/policies/**/admission-webhooks/**/*'

--- a/.github/workflows/pr-labelling.yaml
+++ b/.github/workflows/pr-labelling.yaml
@@ -1,7 +1,7 @@
 name: PR Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
@@ -12,11 +12,11 @@ permissions:
   pull-requests: write
 
 jobs:
-  label:
+  labeler:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Apply labels
         uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1

--- a/.github/workflows/pr-labelling.yaml
+++ b/.github/workflows/pr-labelling.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Apply labels
+      - name: Label PR based on changed files
         uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-labelling.yaml
+++ b/.github/workflows/pr-labelling.yaml
@@ -1,0 +1,26 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.1
+
+      - name: Apply labels
+        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: '.github/labels.yml'
+          sync-labels: true


### PR DESCRIPTION
## Related issue
This PR Fixes: #2018 

This PR adds a GitHub Actions workflow that automatically applies labels to pull requests based on the files changed in the PR. This helps categorize pull requests without requiring labels to be applied manually

## Proposed Changes

- Add `labels.yml` configuration that defines labels to be applied on the files.

- Add `pr-labelling.yaml` workflow that listen on pull request event and applies relevant labels depending on modified files.

- Enabled automatic label synchronization for updated pull requests


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
