### PR TITLE
docs: add community and adoption page with CNCF survey and case study links

### DIFF
--- a/src/content/docs/docs/guides/security.md
+++ b/src/content/docs/docs/guides/security.md
@@ -33,6 +33,13 @@ A [Kyverno Third-Party Security Audit](https://kyverno.io/blog/2023-security-aud
 The [Kyverno Fuzzing Security Audit](https://kyverno.io/blog/fuzzing-audit/assets/kyverno-2023-fuzzing-security-audit.pdf) was conducted as part of the CNCF's security initiative. Fuzz testing, or fuzzing, is an automated process that injects random inputs into the system to reveal defects and vulnerabilities. The audit, spanning July and August 2023, resulted in 15 fuzzers identifying three bugs. Post-audit, Kyverno continues to test for bugs and vulnerabilities using [OSS-Fuzz](https://github.com/google/oss-fuzz).
 The audit's findings prompted fixes and ongoing testing to ensure a secure and robust code base. You can read more about the fuzz testing [in this blog post](https://kyverno.io/blog/2023/09/06/fuzzing-audit/).
 
+### CNCF TAG Security Assessments
+
+As part of the CNCF graduation process, Kyverno has undergone security assessments by the CNCF Technical Advisory Group for Security (TAG Security):
+
+- [Self-assessment](https://github.com/cncf/tag-security/blob/main/community/assessments/projects/kyverno/self-assessment.md) — prepared by the Kyverno maintainers, covering the project's security posture, threat model, and compliance with CNCF security best practices.
+- Joint assessment — a collaborative assessment between the Kyverno team and CNCF TAG Security reviewers; currently in progress and will be published at the [TAG Security assessments directory](https://github.com/cncf/tag-security/tree/main/community/assessments/projects/kyverno) upon completion.
+
 ## Contact Us
 
 To communicate with the Kyverno team, for any questions or discussions, use [Slack](https://slack.k8s.io/#kyverno) or [GitHub](https://github.com/kyverno/kyverno).

--- a/src/content/docs/docs/introduction/community.md
+++ b/src/content/docs/docs/introduction/community.md
@@ -1,0 +1,50 @@
+---
+title: Community & Adoption
+linkTitle: Community & Adoption
+sidebar:
+  order: 40
+excerpt: Production adopters, case studies, and community feedback sources for Kyverno
+---
+
+This page consolidates publicly available evidence of Kyverno production adoption, user feedback, and ecosystem recognition. It is maintained to satisfy the CNCF TOC requirement for linkable user-research and adoption data (ref [issue #15473](https://github.com/kyverno/kyverno/issues/15473)).
+
+## Production Adopters
+
+Kyverno is used in production by organizations across finance, telecommunications, government, cloud providers, and e-commerce. The full list of organizations that have publicly shared their usage is maintained in [ADOPTERS.md](https://github.com/kyverno/kyverno/blob/main/ADOPTERS.md) in the project repository.
+
+Notable adopters include:
+
+- **Spotify** — Uses Kyverno extensively for admission controller capabilities, including best practices and environment-specific data. Spotify received the [CNCF Top End User Award 2023](https://www.cncf.io/announcements/2023/11/08/cloud-native-computing-foundation-presents-the-top-end-user-award-to-spotify/) in part for this work.
+- **US DoD Platform One** — The US Department of Defense Platform One uses Kyverno as its default policy engine for Kubernetes.
+- **Deutsche Telekom** — Uses Kyverno to enforce policies on managed clusters to prevent privilege escalation and enforce security rules.
+- **Bloomberg** — Uses Kyverno to replace custom validation and mutation webhooks in their internal Kubernetes-based platforms.
+- **Vodafone** — Policy enforcement and automation on an internal Kubernetes service offering.
+- **LinkedIn** — Policy enforcement on on-prem Kubernetes clusters.
+
+## Adopter Case Studies and Blog Posts
+
+The following posts on the Kyverno blog document real-world usage patterns and adopter experiences:
+
+- **[Policy-as-Code on Alibaba Cloud ACK](https://kyverno.io/blog/2026/02/13/policy-as-code-on-alibaba-cloud-container-service-for-kubernetes-flexible-kubernetes-governance-with-kyverno/)** (2026) — Flexible Kubernetes governance with Kyverno on Alibaba Cloud Container Service for Kubernetes, co-authored by engineers from Alibaba Cloud and Nirmata.
+- **[Automating EKS CIS Compliance with Kyverno and KubeBench](https://kyverno.io/blog/2025/06/11/automating-eks-cis-compliance-with-kyverno-and-kubebench/)** (2025) — Practical approach to automating CIS compliance for Amazon EKS at scale.
+- **[PodSecurityPolicy Migration with Kyverno](https://kyverno.io/blog/2023/05/24/podsecuritypolicy-migration-with-kyverno/)** (2023) — Migration guide used widely by organizations upgrading past Kubernetes v1.25.
+- **[Simplifying OpenShift MachineSet Management Using Kyverno](https://kyverno.io/blog/2023/07/28/simplifying-openshift-machineset-management-using-kyverno/)** (2023) — Red Hat engineer demonstrates mutation use cases on OpenShift.
+
+## CNCF Annual Survey Data
+
+Kyverno is included in the CNCF Annual Survey as part of the policy management / security tooling category. The following survey reports are publicly available:
+
+- [CNCF Annual Survey 2022](https://www.cncf.io/reports/cncf-annual-survey-2022/)
+- [CNCF Annual Survey 2023](https://www.cncf.io/reports/cncf-annual-survey-2023/)
+- [CNCF Annual Survey 2024](https://www.cncf.io/reports/cncf-annual-survey-2024/)
+
+## Community Feedback Channels
+
+User feedback is collected through the following public channels:
+
+- **[GitHub Issues](https://github.com/kyverno/kyverno/issues)** — Feature requests, bug reports, and usage questions
+- **[Slack (#kyverno)](https://slack.k8s.io/)** — Real-time community discussion in the Kubernetes Slack workspace
+- **[Kyverno Community Meetings](https://kyverno.io/community/)** — Bi-weekly calls open to all; adopters regularly share use cases and request features
+- **[CNCF End User Survey](https://www.cncf.io/enduser/)** — Kyverno is included in the annual CNCF survey of end users
+
+Formal UX research studies and structured adopter interviews have not yet been conducted. This is a recognized gap and is tracked in [issue #15473](https://github.com/kyverno/kyverno/issues/15473).


### PR DESCRIPTION
Ref kyverno/kyverno#15473.

Adds a new **Community & Adoption** page (`docs/introduction/community.md`) consolidating:

- Notable production adopters with context (Spotify CNCF Top End User Award, US DoD Platform One, Deutsche Telekom, Bloomberg, etc.)
- Adopter case study blog posts (Alibaba Cloud ACK, EKS CIS compliance, PSP migration, OpenShift MachineSet)
- Links to CNCF Annual Survey 2022/2023/2024 reports
- Community feedback channels (GitHub, Slack, community meetings, CNCF End User Survey)
- Honest statement that formal UX research studies have not yet been conducted

This satisfies CNCF TOC audit item #2 (UX/user research links) by providing a single, linkable, publicly accessible location for adoption evidence.