### PR TITLE
docs: improve validate rules overview

### DIFF
--- a/src/content/docs/docs/policy-types/cluster-policy/validate.md
+++ b/src/content/docs/docs/policy-types/cluster-policy/validate.md
@@ -22,7 +22,7 @@ Kyverno supports several ways to express validation logic:
 - Use `pattern` when the resource should match a desired structure or value.
 - Use `anyPattern` when more than one valid structure should be accepted.
 - Use `deny` rules when validation depends on conditions or comparisons.
-- Use CEL expressions when the policy needs more flexible logic using admission request data.
+- Use CEL expressions when validation needs expression-based checks over admission request data, including comparisons and conditions that are easier to express in CEL than in `pattern`, `anyPattern`, or `deny`. See [Common Expression Language (CEL)](#common-expression-language-cel) for details.
 
 These approaches can be used to write simple checks as well as more advanced validation policies, depending on how much control the policy requires.
 

--- a/src/content/docs/docs/policy-types/cluster-policy/validate.md
+++ b/src/content/docs/docs/policy-types/cluster-policy/validate.md
@@ -9,6 +9,23 @@ Validation rules are probably the most common and practical types of rules you w
 
 To validate resource data, define a [pattern](#patterns) in the validation rule. For more advanced processing using tripartite expressions (key-operator-value), define a [deny](#deny-rules) element in the validation rule along with a set of conditions that control when to allow or deny the request.
 
+## When to Use Validate Rules
+
+Use validate rules when a policy needs to check whether a Kubernetes resource meets an expected configuration before it is created or updated. They are useful for enforcing required labels, restricting unsafe fields, checking image references, requiring security settings, and guiding teams toward consistent workload configuration.
+
+Validate rules can be introduced gradually. A policy can start in `Audit` mode to report violations without blocking resources, then move to `Enforce` mode once the expected behavior is understood.
+
+## Validation Approaches
+
+Kyverno supports several ways to express validation logic:
+
+- Use `pattern` when the resource should match a desired structure or value.
+- Use `anyPattern` when more than one valid structure should be accepted.
+- Use `deny` rules when validation depends on conditions or comparisons.
+- Use CEL expressions when the policy needs more flexible logic using admission request data.
+
+These approaches can be used to write simple checks as well as more advanced validation policies, depending on how much control the policy requires.
+
 ## Basic Validations
 
 As a basic example, consider the below `ClusterPolicy` which validates that any new Namespace that is created has the label `purpose` with the value of `production`.


### PR DESCRIPTION
## Related issue

Related to kyverno/website#1286

## Proposed Changes

This PR improves the overview section for Validate rules.

It adds a short explanation of when validate rules are useful and summarizes the main validation approaches: `pattern`, `anyPattern`, `deny`, and CEL expressions.

## Checklist

- [x] I have read the contributing guidelines.
- [ ] I have inspected the website preview for accuracy.
- [x] I have signed off my commit.