### PR TITLE
fix(docs): redirect docs root to introduction page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -202,4 +202,7 @@ export default defineConfig({
       }),
     ],
   },
+  redirects: {
+    '/docs': '/docs/introduction/',
+  },
 })


### PR DESCRIPTION
## Related issue
#2036 

## Proposed Changes

- Added redirects for[ /docs](https://kyverno.io/docs/) and /docs/

- Redirected both routes to[ /docs/introduction/](https://kyverno.io/docs/introduction/)

- Improved temporary documentation UX for users directly visiting the docs root

- Prevented users from landing on an almost empty documentation page


## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
