### PR TITLE
fix: Remove wildcard redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -329,12 +329,6 @@
   status = 301
   force = true
 
-# Fallback redirect (must be last)
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
-
 # --- Headers ---
 [[headers]]
   for = "/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -334,9 +334,16 @@
   for = "/*"
   [headers.values]
     X-Frame-Options = "SAMEORIGIN"
-    # Short cache for HTML: avoids repeated 304s within a session while
-    # still picking up new deploys within a minute.
-    Cache-Control = "public, max-age=300, must-revalidate"
+    # Cache HTML briefly, then allow stale responses while Netlify refreshes
+    # in the background to reduce repeat origin requests.
+    Cache-Control = "public, max-age=300, stale-while-revalidate=86400"
+
+# Docs are the hottest traffic surface; cache them longer to reduce request
+# volume while still allowing fast background refreshes.
+[[headers]]
+  for = "/docs/*"
+  [headers.values]
+    Cache-Control = "public, max-age=1800, stale-while-revalidate=86400"
 
 # Astro fingerprints every JS/CSS/image under /_astro/ with a content hash,
 # so these files are safe to cache forever — changing content gets a new URL.

--- a/netlify.toml
+++ b/netlify.toml
@@ -39,6 +39,19 @@
     SITE_URL = "$DEPLOY_PRIME_URL"
 
 # --- Documentation reorganization redirects (commit f4503dcc) ---
+# Docs landing page
+[[redirects]]
+  from = "/docs"
+  to = "/docs/introduction/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/"
+  to = "/docs/introduction/"
+  status = 301
+  force = true
+
 # Applying policies - deleted, moved to guides
 [[redirects]]
   from = "/docs/applying-policies"

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -141,12 +141,12 @@ export const supportLinks = [
 ]
 
 export const ResourcesLinks = [
-  { href: 'docs/introduction', text: 'Documentation' },
+  { href: '/docs/introduction', text: 'Documentation' },
   {
     href: 'https://kyverno.io/docs/kyverno-cli/reference/',
     text: 'API Reference',
   },
-  { href: 'policies', text: 'Policy Samples' },
+  { href: '/policies', text: 'Policy Samples' },
   { href: '#', text: 'Blog' },
 ]
 


### PR DESCRIPTION
## Description

Continue improving website load by:
- Removing useless netlify `/*` wilcard causing redirect loops for crawlers (clear 404 now)
- Improve caching of `/docs` patterns
- Add `stale-while-revalidate` to `Cache-Control`
- Prefix some urls that were missing their `/`