### PR TITLE
fix: update CEL libraries documentation

### DIFF
--- a/src/content/docs/docs/policy-types/cel-libraries.mdx
+++ b/src/content/docs/docs/policy-types/cel-libraries.mdx
@@ -311,7 +311,7 @@ The **Image library** offers functions to parse and analyze image references. It
 | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | `image("nginx:latest")`                                                                     | Convert an image string into an image object (must be used before calling any image methods) |
 | `isImage("nginx:latest")`                                                                   | Check if the string is a valid image                                                         |
-| `image("nginx:latest").registry()`                                                          | Get the image registry (e.g., `docker.io`)                                                   |
+| `image("nginx:latest").registry()`                                                          | Get the image registry (e.g., `index.docker.io`)                                             |
 | `image("nginx:latest").repository()`                                                        | Get the image repository path (e.g., `library/nginx`)                                        |
 | `image("nginx:latest").identifier()`                                                        | Get the image identifier (e.g., tag or digest part)                                          |
 | `image("nginx:latest").tag()`                                                               | Get the tag portion of the image (e.g., `latest`)                                            |
@@ -463,11 +463,11 @@ By leveraging **Global Context**, Kyverno eliminates redundant queries and enabl
 
 The **Hash library** introduces the ability to run hash functions on arbitrary values. This can be used for verification as well as mutating objects with hash information.
 
-| **CEL Expression**     | **Purpose**                                         |
-| ---------------------- | --------------------------------------------------- |
-| `md5("somestring")`    | Obtain the md5 hash of an arbitrary string value    |
-| `sha1("somestring")`   | Obtain the sha1 hash of an arbitrary string value   |
-| `sha256("somestring")` | Obtain the sha256 hash of an arbitrary string value |
+| **CEL Expression**          | **Purpose**                                         |
+| --------------------------- | --------------------------------------------------- |
+| `hash.md5("somestring")`    | Obtain the md5 hash of an arbitrary string value    |
+| `hash.sha1("somestring")`   | Obtain the sha1 hash of an arbitrary string value   |
+| `hash.sha256("somestring")` | Obtain the sha256 hash of an arbitrary string value |
 
 The following policy ensures that the hash of the image name in a certain deployment matches the required value which represents `nginx:latest`:
 
@@ -489,7 +489,7 @@ spec:
         "403554a5dfea78d1ca4a8ff5830ac2ae"
     - name: md5sum
       expression: >-
-        md5(object.spec.template.spec.containers[0].image)
+        hash.md5(object.spec.template.spec.containers[0].image)
     - name: accept
       expression: >-
         variables.md5sum == variables.expectedHash
@@ -594,11 +594,11 @@ spec:
 
 The **Transform library** provides data transformation utilities for converting between different data structures. The `listObjToMap()` function merges two lists of objects into a map by extracting specified key and value fields.
 
-| CEL Expression                                                                                                                      | Purpose                                    |
-| ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| `listObjToMap([{"name": "app1"}], [{"version": "v1"}], "name", "version")`                                                          | Create map `{"app1": "v1"}` from two lists |
-| `listObjToMap([{"id": "x"}, {"id": "y"}], [{"val": 1}, {"val": 2}], "id", "val")`                                                   | Create map `{"x": 1, "y": 2}`              |
-| `listObjToMap(object.spec.containers.map(c, {"name": c.name}), object.spec.containers.map(c, {"image": c.image}), "name", "image")` | Map container names to images              |
+| CEL Expression                                                                                                                                | Purpose                                    |
+| --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `transform.listObjToMap([{"name": "app1"}], [{"version": "v1"}], "name", "version")`                                                          | Create map `{"app1": "v1"}` from two lists |
+| `transform.listObjToMap([{"id": "x"}, {"id": "y"}], [{"val": 1}, {"val": 2}], "id", "val")`                                                   | Create map `{"x": 1, "y": 2}`              |
+| `transform.listObjToMap(object.spec.containers.map(c, {"name": c.name}), object.spec.containers.map(c, {"image": c.image}), "name", "image")` | Map container names to images              |
 
 This sample policy validates that container environment variables match expected values:
 
@@ -620,7 +620,7 @@ spec:
   variables:
     - name: envMap
       expression: >-
-        listObjToMap(
+        transform.listObjToMap(
           object.spec.containers[0].env,
           object.spec.containers[0].env,
           "name",
@@ -660,12 +660,15 @@ Error from server: error when creating "STDIN": admission webhook "vpol.validate
 
 The **JSON library** provides JSON parsing capabilities through the `json.unmarshal()` function, which converts JSON strings into structured data that can be used in policy expressions.
 
-| CEL Expression                                          | Purpose                       |
-| ------------------------------------------------------- | ----------------------------- |
-| `json.unmarshal('{"key": "value"}')`                    | Parse JSON string into map    |
-| `json.unmarshal('{"count": 5}').count`                  | Parse and access nested field |
-| `json.unmarshal('[1, 2, 3]')`                           | Parse JSON array              |
-| `json.unmarshal(object.metadata.annotations['config'])` | Parse JSON from annotation    |
+| CEL Expression                                          | Purpose                            |
+| ------------------------------------------------------- | ---------------------------------- |
+| `json.unmarshal('{"key": "value"}')`                    | Parse JSON string into map         |
+| `json.unmarshal('{"count": 5}').count`                  | Parse and access nested field      |
+| `json.unmarshal('[1, 2, 3]')`                           | Parse JSON array                   |
+| `json.unmarshal(object.metadata.annotations['config'])` | Parse JSON from annotation         |
+| `json.marshal({"key": "value"})`                        | Serialize map to a JSON string     |
+| `json.marshal([1, 2, 3])`                               | Serialize list to a JSON string    |
+| `json.marshal(true)`                                    | Serialize boolean to a JSON string |
 
 This sample policy validates configuration stored as JSON in annotations:
 


### PR DESCRIPTION
## Related issue

N/A

## Proposed Changes

* The registry of a Docker Hub image has been changed to reflect https://github.com/google/go-containerregistry/issues/68
* The `hash` and `transform` libraries had just `func()` instead of `lib.func()`
* `json.marshal(...)` method is usable but not documented

The changes are as per https://github.com/kyverno/sdk/tree/29a100fa834cf2470b433a6a68fac77e82cc66ed - as that's the commit used for the `go.mod` file in Kyverno

https://github.com/kyverno/kyverno/blob/df188b55953768263f6ed136aa6a3c9a770e5c17/go.mod#L41

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [X] I have inspected the website preview for accuracy.
- [X] I have signed off my issue.
