### PR TITLE
feat: Add verify-image-slsa policy to website

### DIFF
--- a/src/content/policies/other-ivpol/verify-image-slsa/verify-image-slsa.md
+++ b/src/content/policies/other-ivpol/verify-image-slsa/verify-image-slsa.md
@@ -1,0 +1,68 @@
+---
+title: 'Verify SLSA Provenance (Keyless)'
+category: verifyImages
+severity: medium
+type: ImageValidatingPolicy
+subjects:
+  - Pod
+tags:
+  - Software Supply Chain Security
+version: 1.18.0
+description: 'Provenance is used to identify how an artifact was produced and from where it originated. SLSA provenance is an industry-standard method of representing that provenance. This policy verifies that an image has SLSA provenance and was signed by the expected subject and issuer when produced through GitHub Actions. It requires configuration based upon your own values.'
+createdAt: "2026-05-20T07:15:05.000Z"
+---
+
+## Policy Definition
+
+<a href="https://github.com/kyverno/policies/raw/main/other-ivpol/verify-image-slsa/verify-image-slsa.yaml" target="-blank">/other-ivpol/verify-image-slsa/verify-image-slsa.yaml</a>
+
+```yaml
+apiVersion: policies.kyverno.io/v1
+kind: ImageValidatingPolicy
+metadata:
+  name: verify-slsa-provenance-keyless
+  annotations:
+    policies.kyverno.io/title: Verify SLSA Provenance (Keyless)
+    policies.kyverno.io/category: Software Supply Chain Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.18.0
+    policies.kyverno.io/description: Provenance is used to identify how an artifact was produced and from where it originated. SLSA provenance is an industry-standard method of representing that provenance. This policy verifies that an image has SLSA provenance and was signed by the expected subject and issuer when produced through GitHub Actions. It requires configuration based upon your own values.
+spec:
+  validationActions:
+    - Deny
+  webhookConfiguration:
+    timeoutSeconds: 30
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - pods
+  matchImageReferences:
+    - glob: myreg.org/path/repo:*
+  attestors:
+    - name: cosign
+      cosign:
+        keyless:
+          identities:
+            - subject: https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v*
+              issuer: https://token.actions.githubusercontent.com
+        ctlog:
+          url: https://rekor.sigstore.dev
+  attestations:
+    - name: slsaProvenance
+      intoto:
+        type: https://slsa.dev/provenance/v0.2
+  validations:
+    - message: Failed to verify SLSA provenance attestation signature with Cosign keyless
+      expression: images.containers.map(image, verifyAttestationSignatures(image, attestations.slsaProvenance, [attestors.cosign])).all(e, e > 0)
+    - message: builder.id in the attestation is not equal to the official SLSA provenance generator workflow
+      expression: images.containers.map(image, extractPayload(image, attestations.slsaProvenance).builder.id.matches('^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9].[0-9].[0-9]$')).all(e, e)
+
+```


### PR DESCRIPTION
## Related issue

https://github.com/kyverno/policies/issues/1488

## Proposed Changes

Generated the merged policy `verify-slsa-provenance-keyless` in https://github.com/kyverno/policies/pull/1487 to be displayed on the website

## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
