### PR TITLE
feat: Add support for fluid-width

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -28,6 +28,7 @@ export default defineConfig({
       favicon: '/favicon.svg',
       customCss: ['./src/styles/global.css'],
       components: {
+        Header: './src/components/StarlightHeader.astro',
         PageSidebar: './src/components/PageSidebar.astro',
         ThemeSelect: './src/components/ThemeSelect.astro',
       },

--- a/src/components/LayoutWidthToggle.jsx
+++ b/src/components/LayoutWidthToggle.jsx
@@ -1,0 +1,37 @@
+import { Maximize2, Minimize2 } from 'lucide-react'
+
+import React from 'react'
+import { useLayoutWidth } from '../hooks/useLayoutWidth'
+
+export const LayoutWidthToggle = () => {
+  const { layoutWidth, toggleLayoutWidth, mounted } = useLayoutWidth()
+
+  if (!mounted) {
+    return (
+      <button
+        className="p-2 rounded-lg border border-stroke text-theme-primary hover:bg-dark-50 transition-colors duration-200"
+        aria-label="Toggle layout width"
+        disabled
+      >
+        <Minimize2 className="w-5 h-5" />
+      </button>
+    )
+  }
+
+  const isFluid = layoutWidth === 'fluid'
+
+  return (
+    <button
+      onClick={toggleLayoutWidth}
+      className="p-2 rounded-lg border border-stroke text-theme-primary hover:bg-dark-50 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:ring-offset-2"
+      aria-label={isFluid ? 'Switch to fixed width' : 'Switch to fluid width'}
+      title={isFluid ? 'Switch to fixed width' : 'Switch to fluid width'}
+    >
+      {isFluid ? (
+        <Minimize2 className="w-5 h-5" />
+      ) : (
+        <Maximize2 className="w-5 h-5" />
+      )}
+    </button>
+  )
+}

--- a/src/components/StarlightHeader.astro
+++ b/src/components/StarlightHeader.astro
@@ -1,0 +1,114 @@
+---
+import config from 'virtual:starlight/user-config'
+
+import LanguageSelect from 'virtual:starlight/components/LanguageSelect'
+import { LayoutWidthToggle } from '../components/LayoutWidthToggle.jsx'
+import Search from 'virtual:starlight/components/Search'
+import SiteTitle from 'virtual:starlight/components/SiteTitle'
+import SocialIcons from 'virtual:starlight/components/SocialIcons'
+import ThemeSelect from 'virtual:starlight/components/ThemeSelect'
+
+const shouldRenderSearch =
+  config.pagefind ||
+  config.components.Search !== '@astrojs/starlight/components/Search.astro'
+---
+
+<div class="header">
+  <div class="title-wrapper sl-flex">
+    <SiteTitle />
+  </div>
+  <div class="sl-flex print:hidden">
+    {shouldRenderSearch && <Search />}
+  </div>
+  <div class="sl-hidden md:sl-flex print:hidden right-group">
+    <div class="sl-flex social-icons">
+      <SocialIcons />
+    </div>
+    <ThemeSelect />
+    <div class="starlight-layout-toggle">
+      <LayoutWidthToggle client:load />
+    </div>
+    <LanguageSelect />
+  </div>
+</div>
+
+<style>
+  @layer starlight.core {
+    .header {
+      display: flex;
+      gap: var(--sl-nav-gap);
+      justify-content: space-between;
+      align-items: center;
+      height: 100%;
+    }
+
+    .title-wrapper {
+      overflow: clip;
+      padding: 0.25rem;
+      margin: -0.25rem;
+      min-width: 0;
+    }
+
+    .right-group,
+    .social-icons {
+      gap: 1rem;
+      align-items: center;
+    }
+    .social-icons::after {
+      content: '';
+      height: 2rem;
+      border-inline-end: 1px solid var(--sl-color-gray-5);
+    }
+
+    .starlight-layout-toggle {
+      display: flex;
+      align-items: center;
+    }
+
+    .starlight-layout-toggle button {
+      color: var(--sl-color-gray-1);
+      border-color: var(--sl-color-gray-5);
+    }
+
+    .starlight-layout-toggle button:hover {
+      color: var(--sl-color-white);
+      background-color: var(--sl-color-gray-6);
+    }
+
+    @media (min-width: 50rem) {
+      :global(:root[data-has-sidebar]) {
+        --__sidebar-pad: calc(2 * var(--sl-nav-pad-x));
+      }
+      :global(:root:not([data-has-toc])) {
+        --__toc-width: 0rem;
+      }
+      .header {
+        --__sidebar-width: max(
+          0rem,
+          var(--sl-content-inline-start, 0rem) - var(--sl-nav-pad-x)
+        );
+        --__main-column-fr: calc(
+          (
+              100% + var(--__sidebar-pad, 0rem) -
+                var(--__toc-width, var(--sl-sidebar-width)) -
+                (2 * var(--__toc-width, var(--sl-nav-pad-x))) -
+                var(--sl-content-inline-start, 0rem) - var(--sl-content-width)
+            ) /
+            2
+        );
+        display: grid;
+        grid-template-columns:
+          minmax(
+            calc(
+              var(--__sidebar-width) +
+                max(0rem, var(--__main-column-fr) - var(--sl-nav-gap))
+            ),
+            auto
+          )
+          1fr
+          auto;
+        align-content: center;
+      }
+    }
+  }
+</style>

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -2,6 +2,7 @@ import { Menu, X } from 'lucide-react'
 import React, { useState } from 'react'
 
 import { Button } from '../components/Button.jsx'
+import { LayoutWidthToggle } from '../components/LayoutWidthToggle.jsx'
 import { SiteLogo } from '../components/SiteLogo.jsx'
 import { ThemeToggle } from '../components/ThemeToggle.jsx'
 import { TopNavLinks } from '../components/TopNavLinks.jsx'
@@ -74,6 +75,7 @@ export const TopNav = () => {
             <Button href="/support" variant="accent" size="large">
               Support
             </Button>
+            <LayoutWidthToggle />
             <ThemeToggle />
           </div>
           <div className="xl:hidden flex flex-col justify-end">
@@ -104,6 +106,7 @@ export const TopNav = () => {
                   Support
                 </Button>
               </div>
+              <LayoutWidthToggle />
               <ThemeToggle />
             </div>
           </div>

--- a/src/design-tokens.js
+++ b/src/design-tokens.js
@@ -31,6 +31,7 @@ export const container = {
   maxWidth: 'max-w-7xl',
   center: 'mx-auto',
   standard: 'max-w-7xl mx-auto',
+  fluid: 'max-w-full mx-auto',
 }
 
 // Vertical Spacing

--- a/src/hooks/useLayoutWidth.jsx
+++ b/src/hooks/useLayoutWidth.jsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState } from 'react'
+
+const STORAGE_KEY = 'kyverno-layout-width'
+
+export const useLayoutWidth = () => {
+  const [layoutWidth, setLayoutWidthState] = useState('fixed')
+  const [mounted, setMounted] = useState(false)
+  const layoutWidthRef = useRef(layoutWidth)
+
+  const getStoredWidth = () => {
+    if (typeof window === 'undefined') return 'fixed'
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === 'fluid') return 'fluid'
+    return 'fixed'
+  }
+
+  const applyWidth = (width) => {
+    if (typeof window !== 'undefined') {
+      if (width === 'fluid') {
+        document.documentElement.setAttribute('data-layout-width', 'fluid')
+      } else {
+        document.documentElement.removeAttribute('data-layout-width')
+      }
+    }
+  }
+
+  const setLayoutWidth = (newWidth) => {
+    const validWidth = newWidth === 'fluid' ? 'fluid' : 'fixed'
+    setLayoutWidthState(validWidth)
+    layoutWidthRef.current = validWidth
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(STORAGE_KEY, validWidth)
+      applyWidth(validWidth)
+    }
+  }
+
+  const toggleLayoutWidth = () => {
+    setLayoutWidth(layoutWidth === 'fixed' ? 'fluid' : 'fixed')
+  }
+
+  useEffect(() => {
+    setMounted(true)
+
+    const initialWidth = getStoredWidth()
+    setLayoutWidthState(initialWidth)
+    layoutWidthRef.current = initialWidth
+    applyWidth(initialWidth)
+
+    if (!localStorage.getItem(STORAGE_KEY)) {
+      localStorage.setItem(STORAGE_KEY, 'fixed')
+    }
+
+    const observer = new MutationObserver(() => {
+      const hasAttr = document.documentElement.hasAttribute('data-layout-width')
+      const currentWidth = hasAttr ? 'fluid' : 'fixed'
+      if (currentWidth !== layoutWidthRef.current) {
+        setLayoutWidthState(currentWidth)
+        layoutWidthRef.current = currentWidth
+        if (typeof window !== 'undefined') {
+          localStorage.setItem(STORAGE_KEY, currentWidth)
+        }
+      }
+    })
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-layout-width'],
+    })
+
+    const handleStorageChange = (e) => {
+      if (e.key === STORAGE_KEY) {
+        const newWidth = e.newValue === 'fluid' ? 'fluid' : 'fixed'
+        setLayoutWidthState(newWidth)
+        layoutWidthRef.current = newWidth
+        applyWidth(newWidth)
+      }
+    }
+
+    window.addEventListener('storage', handleStorageChange)
+
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('storage', handleStorageChange)
+    }
+  }, [])
+
+  return {
+    layoutWidth,
+    toggleLayoutWidth,
+    setLayoutWidth,
+    mounted,
+  }
+}

--- a/src/layouts/DefaultLayout.astro
+++ b/src/layouts/DefaultLayout.astro
@@ -28,6 +28,16 @@ import '../styles/global.css'
         }
       })()
     </script>
+    <script is:inline>
+      ;(function () {
+        try {
+          const stored = localStorage.getItem('kyverno-layout-width')
+          if (stored === 'fluid') {
+            document.documentElement.setAttribute('data-layout-width', 'fluid')
+          }
+        } catch (e) {}
+      })()
+    </script>
     <meta
       name="description"
       content="Simplify cloud-native governance with Kyverno. Automate Kubernetes security, ensure resource compliance, and empower Platform Engineers to manage infrastructure and applications using native YAML-based declarative policy-as-code."

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -219,6 +219,37 @@ details summary::marker {
   display: none;
 }
 
+/* === Fluid Width Overrides === */
+html[data-layout-width='fluid'] .sl-container {
+  max-width: 100% !important;
+}
+
+html[data-layout-width='fluid'] .main-pane {
+  width: 100% !important;
+}
+
+html[data-layout-width='fluid'] [data-has-sidebar][data-has-toc] .main-pane {
+  --sl-content-margin-inline: auto !important;
+  width: 100% !important;
+}
+
+html[data-layout-width='fluid'] .max-w-7xl {
+  max-width: 100%;
+}
+
+html[data-layout-width='fluid'] .max-w-4xl {
+  max-width: 100%;
+}
+
+html[data-layout-width='fluid'] .max-w-\[1600px\] {
+  max-width: 100%;
+}
+
+html[data-layout-width='fluid'] .content-panel {
+  padding-left: max(1rem, var(--sl-content-pad-x, 1rem)) !important;
+  padding-right: max(1rem, var(--sl-content-pad-x, 1rem)) !important;
+}
+
 /* Hide scrollbar for horizontal scrolling on mobile */
 .scrollbar-hide {
   -ms-overflow-style: none; /* IE and Edge */


### PR DESCRIPTION
## Related issue

Closes #2058 

## Why it's needed?
Fixed web page size makes text centralized which seems good for reading normal text but when it comes to code snippets that contains large sentences or tables such as: https://kyverno.io/docs/installation/customization/#container-flags it becomes harder to read and swinging right and left is not practical.

## Proposed Changes

Add toggle button to switch between fluid (stretched) and fixed width

## Before
<img width="2560" height="1358" alt="Screenshot 2026-06-01 at 6 10 38 AM" src="https://github.com/user-attachments/assets/c290c49e-0e65-41b6-945b-6d56c7f4de7b" />

## After
<img width="2560" height="1358" alt="Screenshot 2026-06-01 at 6 10 56 AM" src="https://github.com/user-attachments/assets/a0fee614-df43-4dc4-a3ac-08ff7c451a0f" />


It's applied throughout the entire website but you can feel its importance in a section such as [container flags](https://kyverno.io/docs/installation/customization/#container-flags)

deploy preview: https://deploy-preview-2059--kyverno.netlify.app/

## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
