### PR TITLE
fix: use existing logo asset as favicon instead of missing public fil…

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -180,6 +180,11 @@ export default defineConfig({
       viteStaticCopy({
         targets: [
           {
+            src: 'src/assets/images/kyverno-logo.svg',
+            dest: '.',
+            rename: () => 'favicon.svg',
+          },
+          {
             src: 'src/content/blog/**/assets/*',
             dest: 'blog',
             rename: (name, ext, fullPath) => {

--- a/src/layouts/DefaultLayout.astro
+++ b/src/layouts/DefaultLayout.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/global.css'
+import faviconSvg from '../assets/images/kyverno-logo.svg'
 ---
 
 <!doctype html>
@@ -69,7 +70,7 @@ import '../styles/global.css'
       href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap"
       rel="stylesheet"
     />
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href={faviconSvg.src} type="image/svg+xml" />
   </head>
   <body>
     <slot />


### PR DESCRIPTION
Fixes #2026

The favicon was configured to load from `/favicon.svg` in the `public/` directory, but no such file existed — causing a 404 on docs pages. The browser tab showed a blank/default icon instead of the Kyverno logo.

Instead of adding a separate copy to `public/`, this fix:
- Imports `kyverno-logo.svg` from `src/assets/` in `DefaultLayout.astro` for homepage, blog, and support pages
- Adds a `viteStaticCopy` target in `astro.config.mjs` to serve the same asset as `/favicon.svg` for Starlight docs pages

## Related Issue

Resolves #2026

## Proposed Changes

- **`src/layouts/DefaultLayout.astro`** — Import favicon from `src/assets/images/kyverno-logo.svg` and use processed URL
- **`astro.config.mjs`** — Add static copy target to serve the existing logo as `/favicon.svg`

## Before
<img width="1915" height="1040" alt="Screenshot 2026-06-01 at 10 57 01 PM" src="https://github.com/user-attachments/assets/0ebe9b78-b7e0-4958-aecf-a9c4ffb8980c" />

## After 

<img width="1918" height="1050" alt="Screenshot 2026-06-01 at 10 58 38 PM" src="https://github.com/user-attachments/assets/45fc4cf0-73ec-4eee-a8e9-2cf0002b5561" />


## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
