### PR TITLE
fix: correct broken and misleading footer navigation links

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -141,13 +141,10 @@ export const supportLinks = [
 ]
 
 export const ResourcesLinks = [
-  { href: '/docs/introduction', text: 'Documentation' },
-  {
-    href: 'https://kyverno.io/docs/kyverno-cli/reference/',
-    text: 'API Reference',
-  },
-  { href: '/policies', text: 'Policy Samples' },
-  { href: '#', text: 'Blog' },
+  { href: '/docs/introduction/', text: 'Documentation' },
+  { href: '/docs/crds/', text: 'API Reference' },
+  { href: '/policies/', text: 'Policy Samples' },
+  { href: '/blog/', text: 'Blog' },
 ]
 
 export const communityLinks = [


### PR DESCRIPTION
## Related issue
Fixes #2064 

## Description
Update the footer navigation links to point to the correct destinations and improve navigation consistency across the website.


## Proposed Changes

- Update footer links to use the correct destinations.

- Fix the Blog footer link.

- Correct the API Reference link to point to the appropriate documentation page.

- Verify footer navigation works correctly from nested pages.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
