### PR TITLE
fix: link policy type documentation pages

### DIFF
--- a/src/pages/policies/[...slug].astro
+++ b/src/pages/policies/[...slug].astro
@@ -74,6 +74,19 @@ const severity = data.severity || 'medium'
 const description = data.description || null
 const isNew = isPolicyNew(data.createdAt)
 
+const policyTypeDocs = {
+  ClusterPolicy: '/docs/policy-types/cluster-policy/overview/',
+  Policy: '/docs/policy-types/cluster-policy/overview/#namespaced-policies',
+  ValidatingPolicy: '/docs/policy-types/validating-policy/',
+  ImageValidatingPolicy: '/docs/policy-types/image-validating-policy/',
+  MutatingPolicy: '/docs/policy-types/mutating-policy/',
+  DeletingPolicy: '/docs/policy-types/deleting-policy/',
+  GeneratingPolicy: '/docs/policy-types/generating-policy/',
+  ClusterCleanupPolicy: '/docs/policy-types/cleanup-policy/',
+}
+
+const policyTypeDocUrl = data.type ? policyTypeDocs[data.type] : undefined
+
 // Construct GitHub URL from policy ID
 const githubUrl = `https://github.com/kyverno/policies/blob/main/${policy.id}.yaml`
 
@@ -206,7 +219,18 @@ const relatedPolicies = allPolicies
                 Type
               </dt>
               <dd class="text-theme-primary font-mono text-sm font-medium">
-                {data.type}
+                {
+                  policyTypeDocUrl ? (
+                    <a
+                      href={policyTypeDocUrl}
+                      class="text-primary-100 hover:underline"
+                    >
+                      {data.type}
+                    </a>
+                  ) : (
+                    data.type
+                  )
+                }
               </dd>
             </div>
 

--- a/src/pages/policies/[...slug].astro
+++ b/src/pages/policies/[...slug].astro
@@ -76,7 +76,7 @@ const isNew = isPolicyNew(data.createdAt)
 
 const policyTypeDocs = {
   ClusterPolicy: '/docs/policy-types/cluster-policy/overview/',
-  Policy: '/docs/policy-types/cluster-policy/overview/#namespaced-policies',
+  Policy: '/docs/policy-types/cluster-policy/overview/',
   ValidatingPolicy: '/docs/policy-types/validating-policy/',
   ImageValidatingPolicy: '/docs/policy-types/image-validating-policy/',
   MutatingPolicy: '/docs/policy-types/mutating-policy/',


### PR DESCRIPTION
## Related issue
This PR improves navigation from policy pages by linking policy type references to their corresponding documentation pages.
## Proposed Changes

- Added links for policy type references in src/pages/policies/[...slug].astro.
- Improved discoverability and navigation between policy resources and their documentation.

## Screenshots

### Before
<img width="1200" height="600" alt="1" src="https://github.com/user-attachments/assets/d3f4c35a-6a6c-4f73-a74f-bb6173e36607" />

### After
<img width="1200" height="600" alt="2" src="https://github.com/user-attachments/assets/997040b3-991e-4b60-b4b3-47da6ea95279" />


## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
