### PR TITLE
docs(security): add risks of running without a NetworkPolicy

### DIFF
--- a/src/content/docs/docs/guides/security.md
+++ b/src/content/docs/docs/guides/security.md
@@ -301,9 +301,9 @@ By default, a Kyverno installation does not configure NetworkPolicies (see [this
 
 Without a NetworkPolicy, the webhook is reachable from any pod and its outbound traffic is unrestricted. Several mitigations in the [Threat Model](#threat-model) below assume a NetworkPolicy is in place, leaving these risks:
 
-- **Direct webhook access (Threat IDs 1, 2, 8, 9).** Kyverno does not authenticate the API server, so any pod that reaches port 9443 can flood the webhook or send arbitrary AdmissionReview requests.
-- **Data exfiltration (Threat ID 18).** Policies can send admission-request data to any reachable endpoint, including cloud metadata and link-local addresses. This covers [`apiCall`](/docs/policy-types/cluster-policy/external-data-sources#variables-from-service-calls) with `service.url` and CEL's [HTTP library](/docs/policy-types/cel-libraries#http-library) (`http.Get()` / `http.Post()`).
-- **Controller compromise (Threat ID 4).** The controller can modify Kyverno policies and its own `MutatingWebhookConfiguration` / `ValidatingWebhookConfiguration`, so a compromised pod can silently change what the cluster enforces. With no egress policy, it can also reach the API server and other internal services.
+- Direct webhook access (Threat IDs 1, 2, 8, 9): Kyverno does not authenticate the API server, so any pod that reaches port 9443 can flood the webhook or send arbitrary `AdmissionReview` requests.
+- Data exfiltration (Threat ID 18): Policies can send admission-request data to any reachable endpoint, including cloud metadata and link-local addresses. This covers [`apiCall`](/docs/policy-types/cluster-policy/external-data-sources#variables-from-service-calls) with `apiCall.service.url` and the CEL [HTTP library](/docs/policy-types/cel-libraries#http-library) (`http.Get()` / `http.Post()`).
+- Controller compromise (Threat ID 4): The controller can modify Kyverno policies and its own `MutatingWebhookConfiguration` / `ValidatingWebhookConfiguration`, so a compromised pod can silently change what the cluster enforces. With no egress policy, it can also reach the API server and other internal services.
 
 To mitigate, configure a NetworkPolicy allowing only the flows listed below. NetworkPolicies are only effective if the cluster's CNI enforces them, so confirm CNI support before relying on this control.
 

--- a/src/content/docs/docs/guides/security.md
+++ b/src/content/docs/docs/guides/security.md
@@ -297,6 +297,16 @@ Kyverno network traffic is encrypted and should be restricted using NetworkPolic
 
 By default, a Kyverno installation does not configure NetworkPolicies (see [this issue](https://github.com/kyverno/kyverno/issues/2917)). The [Kyverno Helm chart](https://artifacthub.io/packages/helm/kyverno/kyverno) has a `networkPolicy.enabled` option to enable a NetworkPolicy.
 
+#### Risk of not configuring a NetworkPolicy
+
+When no NetworkPolicy is configured, the Kyverno webhook is reachable from any pod in the cluster and its outbound traffic is unrestricted. Several mitigations in the [Threat Model](#threat-model) below assume a NetworkPolicy is in place, leaving the following risks:
+
+- Kyverno does not authenticate callers of its webhook (Threats 2, 8, 9). Any in-cluster workload that can reach port 9443 can attempt to flood the webhook or spoof admission requests.
+- Policies that fetch external data via [`apiCall`](/docs/policy-types/cluster-policy/external-data-sources#variables-from-service-calls) with a `service.url` can send admission request data to any reachable endpoint, including cloud-provider metadata services and link-local addresses (Threat 18).
+- The admission controller has full CRUD on Kyverno policy CRDs and on its own `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` resources, so a controller-pod compromise can silently rewrite the policy set the cluster enforces. Without an egress NetworkPolicy, the attacker can also reach the Kubernetes API (with the controller's ServiceAccount token) and any other internal service routable from the pod.
+
+To mitigate these risks, configure a NetworkPolicy that allows only the flows listed below; any other traffic to or from the controller is then denied by default.
+
 Kyverno requires the following network communications to be allowed:
 
 - ingress traffic to port 9443 from the API server

--- a/src/content/docs/docs/guides/security.md
+++ b/src/content/docs/docs/guides/security.md
@@ -299,13 +299,13 @@ By default, a Kyverno installation does not configure NetworkPolicies (see [this
 
 #### Risk of not configuring a NetworkPolicy
 
-When no NetworkPolicy is configured, the Kyverno webhook is reachable from any pod in the cluster and its outbound traffic is unrestricted. Several mitigations in the [Threat Model](#threat-model) below assume a NetworkPolicy is in place, leaving the following risks:
+Without a NetworkPolicy, the webhook is reachable from any pod and its outbound traffic is unrestricted. Several mitigations in the [Threat Model](#threat-model) below assume a NetworkPolicy is in place, leaving these risks:
 
-- Kyverno does not authenticate callers of its webhook (Threats 1, 2, 8, 9). Any in-cluster workload that can reach port 9443 can attempt to flood the webhook or spoof admission requests.
-- Policies that fetch external data via [`apiCall`](/docs/policy-types/cluster-policy/external-data-sources#variables-from-service-calls) with a `service.url` can send admission request data to any reachable endpoint, including cloud-provider metadata services and link-local addresses (Threat 18).
-- The admission controller has full CRUD on Kyverno policy CRDs and on its own `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` resources, so a controller-pod compromise can silently rewrite the policy set the cluster enforces. Without an egress NetworkPolicy, the attacker can also reach the Kubernetes API (with the controller's ServiceAccount token) and any other internal service routable from the pod.
+- **Direct webhook access (Threat IDs 1, 2, 8, 9).** Kyverno does not authenticate the API server, so any pod that reaches port 9443 can flood the webhook or send arbitrary AdmissionReview requests.
+- **Data exfiltration (Threat ID 18).** Policies can send admission-request data to any reachable endpoint, including cloud metadata and link-local addresses. This covers [`apiCall`](/docs/policy-types/cluster-policy/external-data-sources#variables-from-service-calls) with `service.url` and CEL's [HTTP library](/docs/policy-types/cel-libraries#http-library) (`http.Get()` / `http.Post()`).
+- **Controller compromise (Threat ID 4).** The controller can modify Kyverno policies and its own `MutatingWebhookConfiguration` / `ValidatingWebhookConfiguration`, so a compromised pod can silently change what the cluster enforces. With no egress policy, it can also reach the API server and other internal services.
 
-To mitigate these risks, configure a NetworkPolicy that allows only the flows listed below; any other traffic to or from the controller is then denied by default.
+To mitigate, configure a NetworkPolicy allowing only the flows listed below. NetworkPolicies are only effective if the cluster's CNI enforces them, so confirm CNI support before relying on this control.
 
 Kyverno requires the following network communications to be allowed:
 

--- a/src/content/docs/docs/guides/security.md
+++ b/src/content/docs/docs/guides/security.md
@@ -301,7 +301,7 @@ By default, a Kyverno installation does not configure NetworkPolicies (see [this
 
 When no NetworkPolicy is configured, the Kyverno webhook is reachable from any pod in the cluster and its outbound traffic is unrestricted. Several mitigations in the [Threat Model](#threat-model) below assume a NetworkPolicy is in place, leaving the following risks:
 
-- Kyverno does not authenticate callers of its webhook (Threats 2, 8, 9). Any in-cluster workload that can reach port 9443 can attempt to flood the webhook or spoof admission requests.
+- Kyverno does not authenticate callers of its webhook (Threats 1, 2, 8, 9). Any in-cluster workload that can reach port 9443 can attempt to flood the webhook or spoof admission requests.
 - Policies that fetch external data via [`apiCall`](/docs/policy-types/cluster-policy/external-data-sources#variables-from-service-calls) with a `service.url` can send admission request data to any reachable endpoint, including cloud-provider metadata services and link-local addresses (Threat 18).
 - The admission controller has full CRUD on Kyverno policy CRDs and on its own `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` resources, so a controller-pod compromise can silently rewrite the policy set the cluster enforces. Without an egress NetworkPolicy, the attacker can also reach the Kubernetes API (with the controller's ServiceAccount token) and any other internal service routable from the pod.
 


### PR DESCRIPTION
## TL;DR

This PR addresses  "Improve docs on the risk of not having a network policy" in kyverno/kyverno#15335

## Context

The changes in this PR will inform users about the risks they are accepting if network policy is not configured. Several mitigations mentioned in the Threat Model quietly assume a NetworkPolicy is in place.

## Change

Adds a `Risk of not configuring a NetworkPolicy` subsection to the Security guide, between the Networking intro and the existing list of allowed flows. Three residual risks, each linked to the page's Threat Model:
- **Unauthenticated webhook** - Any in-cluster pod reaching port 9443 can flood or spoof admission requests. 
- **`apiCall` exfiltration**  - Policies using `service.url` can send admission-request data to metadata services 
- **Controller blast radius** - a compromised Kyverno pod can rewrite policies and reach internal services.


## Scope

Docs-only. 

## Testing

I followed the docs to spin this up locally and was able to see the changes

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my commit.