### PR TITLE
docs(cli): add offline CEL http.Post() mock support and duplicate key validation

### DIFF
--- a/src/content/docs/docs/subprojects/kyverno-cli.mdx
+++ b/src/content/docs/docs/subprojects/kyverno-cli.mdx
@@ -3968,7 +3968,7 @@ The following example tests a `ValidatingPolicy` that calls an external authoriz
 Policy manifest (`policy.yaml`):
 
 ```yaml
-apiVersion: policies.kyverno.io/v1beta1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-pod-admission

--- a/src/content/docs/docs/subprojects/kyverno-cli.mdx
+++ b/src/content/docs/docs/subprojects/kyverno-cli.mdx
@@ -3880,6 +3880,12 @@ The `body` field of each `apiCallResponses` entry accepts any valid JSON value (
 For each `globalContextEntries` entry, `data`, `resources`, and `resourceFiles` are mutually exclusive — provide exactly one. The `resources` and `resourceFiles` options are designed for `kubernetesResource`-backed GlobalContextEntries: the CLI decodes the manifests into the same `[]interface{}` list shape returned by the real Kubernetes informer cache, so JMESPath and CEL projections work identically to production. The `data` option is for arbitrary JSON — useful for mocking any GlobalContextEntry that holds structured data rather than Kubernetes objects.
 :::
 
+:::caution[Duplicate Key Validation]
+Each `apiCallResponses` entry is uniquely identified by its **method + URL** combination. Configuring two entries with the same `method` and `url` is an error — the CLI will reject the test manifest before any evaluation begins. This prevents silent non-deterministic behavior caused by duplicate mocks.
+
+Different HTTP methods to the same URL are valid distinct entries. For example, a `GET` entry and a `POST` entry that both point to `https://authz.example.com/validate` can coexist without conflict.
+:::
+
 #### Mocking CEL `http.Get()` calls
 
 The following example tests a `ValidatingPolicy` that calls an external configuration endpoint using Kyverno's CEL `http.Get()` library function.
@@ -3950,6 +3956,107 @@ Loading test  ( kyverno-test.yaml ) ...
 │ ID │ POLICY                │ RULE │ RESOURCE                    │ RESULT │ REASON │
 │────│───────────────────────│──────│─────────────────────────────│────────│────────│
 │ 1  │ check-external-config │      │ v1/Pod/default/test-pod     │ Pass   │ Ok     │
+│────│───────────────────────│──────│─────────────────────────────│────────│────────│
+
+Test Summary: 1 tests passed and 0 tests failed
+```
+
+#### Mocking CEL `http.Post()` calls
+
+The following example tests a `ValidatingPolicy` that calls an external authorization service using Kyverno's CEL `http.Post()` library function. Both a pass scenario (the service allows the request) and a deny scenario (the service rejects the request) are shown.
+
+Policy manifest (`policy.yaml`):
+
+```yaml
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: check-pod-admission
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ['']
+        apiVersions: ['v1']
+        operations: [CREATE, UPDATE]
+        resources: [pods]
+  validations:
+    - expression: >-
+        http.Post("https://authz.example.com/validate",
+          {"namespace": object.metadata.namespace, "name": object.metadata.name}).body.allowed == true
+      message: 'External authorization service rejected this pod'
+```
+
+Test manifest — pass scenario (`kyverno-test.yaml`):
+
+```yaml
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cel-http-post-mock
+policies:
+  - policy.yaml
+resources:
+  - resources.yaml
+apiCallResponses:
+  - method: POST
+    url: https://authz.example.com/validate
+    response:
+      statusCode: 200
+      body:
+        allowed: true
+results:
+  - isValidatingPolicy: true
+    kind: Pod
+    policy: check-pod-admission
+    resources:
+      - default/test-pod
+    result: pass
+```
+
+Test manifest — deny scenario (`kyverno-test.yaml`):
+
+```yaml
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cel-http-post-mock-deny
+policies:
+  - policy.yaml
+resources:
+  - resources.yaml
+apiCallResponses:
+  - method: POST
+    url: https://authz.example.com/validate
+    response:
+      statusCode: 200
+      body:
+        allowed: false
+results:
+  - isValidatingPolicy: true
+    kind: Pod
+    policy: check-pod-admission
+    resources:
+      - default/test-pod
+    result: fail
+```
+
+Run the test:
+
+```sh
+kyverno test .
+```
+
+Expected output (pass scenario):
+
+```
+Loading test  ( kyverno-test.yaml ) ...
+  Applying 1 policy to 1 resource with 0 exceptions ...
+  Checking results ...
+
+│────│───────────────────────│──────│─────────────────────────────│────────│────────│
+│ ID │ POLICY                │ RULE │ RESOURCE                    │ RESULT │ REASON │
+│────│───────────────────────│──────│─────────────────────────────│────────│────────│
+│ 1  │ check-pod-admission   │      │ v1/Pod/default/test-pod     │ Pass   │ Ok     │
 │────│───────────────────────│──────│─────────────────────────────│────────│────────│
 
 Test Summary: 1 tests passed and 0 tests failed

--- a/src/content/docs/docs/subprojects/kyverno-cli.mdx
+++ b/src/content/docs/docs/subprojects/kyverno-cli.mdx
@@ -3880,7 +3880,7 @@ The `body` field of each `apiCallResponses` entry accepts any valid JSON value (
 For each `globalContextEntries` entry, `data`, `resources`, and `resourceFiles` are mutually exclusive — provide exactly one. The `resources` and `resourceFiles` options are designed for `kubernetesResource`-backed GlobalContextEntries: the CLI decodes the manifests into the same `[]interface{}` list shape returned by the real Kubernetes informer cache, so JMESPath and CEL projections work identically to production. The `data` option is for arbitrary JSON — useful for mocking any GlobalContextEntry that holds structured data rather than Kubernetes objects.
 :::
 
-:::caution[Duplicate Key Validation]
+:::note[Duplicate Key Validation]
 Each `apiCallResponses` entry is uniquely identified by its **method + URL** combination. Configuring two entries with the same `method` and `url` is an error — the CLI will reject the test manifest before any evaluation begins. This prevents silent non-deterministic behavior caused by duplicate mocks.
 
 Different HTTP methods to the same URL are valid distinct entries. For example, a `GET` entry and a `POST` entry that both point to `https://authz.example.com/validate` can coexist without conflict.


### PR DESCRIPTION
## Related issue

Ref kyverno/kyverno#16297 — feat(cli): add CEL http.Post mocking test fixtures, duplicate validation check, and integration tests (merged into kyverno:main)

## Proposed Changes

Documents the offline `http.Post()` mock support for CEL-based policies introduced in kyverno/kyverno#16297 (Kyverno 1.19.0).

Updates `kyverno-cli.mdx` in the "Testing Policies with Offline HTTP Mocks and Global Context" section with the following additions:

1. **Duplicate Key Validation callout** — A `caution` block explaining that each `apiCallResponses` entry is uniquely keyed by its `method + url` combination. Configuring two entries with the same method and URL is a validation error caught before any test runs, preventing silent non-deterministic behavior. Also clarifies that different methods (e.g. `GET` and `POST`) to the same URL are valid and distinct.

2. **New `#### Mocking CEL \`http.Post()\` calls` subsection** — Added directly after the existing `http.Get()` subsection, following the same structure and style. Includes:
   - A sample `ValidatingPolicy` using `http.Post()` in a CEL validation expression
   - A pass scenario `kyverno-test.yaml` (mock returns `allowed: true`, result: pass)
   - A deny scenario `kyverno-test.yaml` (mock returns `allowed: false`, result: fail)
   - The `kyverno test .` command and expected CLI output table

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.