### PR TITLE
fix: correct broken Chainsaw Linux binary download filename in blog

### DIFF
--- a/src/content/blog/introducing-chainsaw/index.md
+++ b/src/content/blog/introducing-chainsaw/index.md
@@ -84,8 +84,8 @@ For Linux users, Chainsaw can be installed using one of the following methods:
    Visit the [Chainsaw releases page](https://github.com/kyverno/chainsaw/releases) and download the appropriate binary for your system. Extract the binary and move it to a directory in your `PATH`.
 
    ```sh
-    wget https://github.com/kyverno/chainsaw/releases/download/v0.2.12/chainsaw-linux-amd64.tar.gz
-   tar -xvf chainsaw-linux-amd64.tar.gz
+    wget https://github.com/kyverno/chainsaw/releases/download/v0.2.12/chainsaw_linux_amd64.tar.gz
+   tar -xvf chainsaw_linux_amd64.tar.gz
    sudo mv chainsaw /usr/local/bin/
    ```
 


### PR DESCRIPTION
## Description

The Linux installation snippet in the *Introducing Chainsaw* blog post downloads `chainsaw-linux-amd64.tar.gz` (hyphens), but the actual GitHub release asset is named `chainsaw_linux_amd64.tar.gz` (underscores). The documented `wget` command therefore fails with a 404.

Verified against the `kyverno/chainsaw` v0.2.12 release assets:
- `chainsaw-linux-amd64.tar.gz` (hyphens) -> 404 Not Found
- `chainsaw_linux_amd64.tar.gz` (underscores) -> exists

This corrects the filename on both the `wget` and `tar` lines so the install steps work as written. No version change.