### PR TITLE
docs(globalcontext): document name field for single-resource lookup

### DIFF
--- a/src/content/docs/docs/policy-types/global-context-caching.md
+++ b/src/content/docs/docs/policy-types/global-context-caching.md
@@ -163,6 +163,7 @@ Use this mode to capture internal topology data, structural metadata, or shared 
 | `version`    | string          | **Yes**     | The explicit API version state (e.g., `v1`, `v1beta1`).                                                                                                                                                                                                                           |
 | `resource`   | string          | **Yes**     | **Must be lowercased and pluralized** (e.g., use `configmaps` or `secrets`, not `ConfigMap`).                                                                                                                                                                                     |
 | `namespace`  | string          | No          | The target namespace boundaries. If omitted, Kyverno tracks across **all namespaces** globally.                                                                                                                                                                                   |
+| `name`      | string          | No          | The name of a specific resource to cache. When set, returns a single object instead of a list. Leave empty to cache all resources of this type. |
 
 > **Important:** Ensure the Kyverno ServiceAccount has the necessary RBAC
 > permissions (`get`, `list`, `watch`) for the resources you are caching,
@@ -182,6 +183,37 @@ spec:
     resource: configmaps
     namespace: default
 ```
+
+#### Syntax Example: Single Resource Lookup
+
+When `name` is specified, the entry returns a single object instead of a list,
+simplifying CEL access in policies.
+
+```yaml
+apiVersion: kyverno.io/v2alpha1
+kind: GlobalContextEntry
+metadata:
+  name: service-registry-cache
+spec:
+  kubernetesResource:
+    group: ''
+    version: v1
+    resource: configmaps
+    namespace: kyverno
+    name: service-registry
+```
+
+In a policy, the data is now directly accessible without unwrapping a list:
+
+```yaml
+# Before (name not set — returns list)
+jmesPath: 'items[?metadata.name==`service-registry`].data.endpoint | [0]'
+
+# After (name set — returns single object)
+jmesPath: 'data.endpoint'
+```
+
+
 
 ### 2. External API Caching
 


### PR DESCRIPTION
## Related issue

Companion docs PR for kyverno/kyverno#15623

## Proposed Changes

Adds documentation for the new name field on spec.kubernetesResource in GlobalContextEntry. When name is specified, the entry returns a single object instead of a list, simplifying CEL access in policies.
Changes:

Added name row to the kubernetesResource schema table
Added "Syntax Example: Single Resource Lookup" section showing before/after CEL access patterns

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
