### PR TITLE
fix: update renamed cert-manager issue link

### DIFF
--- a/src/content/docs/docs/guides/troubleshooting.md
+++ b/src/content/docs/docs/guides/troubleshooting.md
@@ -72,7 +72,7 @@ Use [Namespace selectors](/docs/installation/customization#namespace-selectors) 
 
    The age should be consistent with the age of the currently running Kyverno Pod(s). If the age of these webhooks shows, for example, a few seconds old, Kyverno may be having trouble registering with Kubernetes.
 
-4. Test that name resolution and connectivity to the Kyverno service works inside your cluster by starting a simple `busybox` Pod and trying to connect to Kyverno. Enter the `wget` command as shown below. If the response is not "remote file exists" then there is a network connectivity or DNS issue within your cluster. If your cluster was provisioned with [kubespray](https://github.com/kubernetes-sigs/kubespray), see if [this comment](https://github.com/jetstack/cert-manager/issues/2640#issuecomment-601872165) helps you.
+4. Test that name resolution and connectivity to the Kyverno service works inside your cluster by starting a simple `busybox` Pod and trying to connect to Kyverno. Enter the `wget` command as shown below. If the response is not "remote file exists" then there is a network connectivity or DNS issue within your cluster. If your cluster was provisioned with [kubespray](https://github.com/kubernetes-sigs/kubespray), see if [this comment](https://github.com/cert-manager/cert-manager/issues/2640#issuecomment-601872165) helps you.
 
    ```sh
    $ kubectl run busybox --rm -ti --image=busybox -- /bin/sh


### PR DESCRIPTION
The troubleshooting guide links to a cert-manager issue under the old `jetstack` org:

`https://github.com/jetstack/cert-manager/issues/2640#issuecomment-601872165`

cert-manager was moved from the `jetstack` org to the `cert-manager` org, and GitHub does not redirect old issue permalinks, so the current link returns HTTP 404. Updating the org to `cert-manager` restores the link (returns HTTP 200). Docs-only fix.