### PR TITLE
docs: align keyless regexp example with the image signing identity

### DIFF
--- a/src/content/docs/docs/policy-types/cluster-policy/verify-images/sigstore.md
+++ b/src/content/docs/docs/policy-types/cluster-policy/verify-images/sigstore.md
@@ -581,8 +581,8 @@ spec:
           attestors:
             - entries:
                 - keyless:
-                    subjectRegExp: https://github\.com/.+
-                    issuerRegExp: https://token\.actions\.githubusercontent.+
+                    subjectRegExp: .+@nirmata\.com
+                    issuerRegExp: https://accounts\.google\.com
                     rekor:
                       url: https://rekor.sigstore.dev
 ```


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

Resolves #2093

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

The "Keyless signing and verification" section shows two policies that both verify the same image, `ghcr.io/kyverno/test-verify-image:signed-keyless`. The first uses `subject: '*@nirmata.com'` and `issuer: 'https://accounts.google.com'`, but the second (the regex variant) used a GitHub Actions identity (`subjectRegExp: https://github\.com/.+`, `issuerRegExp: https://token\.actions\.githubusercontent.+`), which does not match how that image is signed. This PR points the regex example at the same identity so the two examples are consistent.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
