### PR TITLE
docs: add YAML template mode to GeneratingPolicy

### DIFF
--- a/src/components/FeatureState.astro
+++ b/src/components/FeatureState.astro
@@ -6,10 +6,7 @@ interface Props {
 
 const { state, version } = Astro.props
 const normalizedState = (state?.toLowerCase() || 'beta') as
-  | 'alpha'
-  | 'beta'
-  | 'stable'
-  | 'deprecated'
+  'alpha' | 'beta' | 'stable' | 'deprecated'
 
 // State configuration with colors and labels
 const stateConfig = {

--- a/src/content/blog/announcing-kyverno-release-1.13/index.md
+++ b/src/content/blog/announcing-kyverno-release-1.13/index.md
@@ -634,7 +634,7 @@ Kyverno 1.13 introduces new changes in the policy CRDs:
 - These are replaced by more granular controls within the rule itself:
   - spec.rules[*].validate.failureAction
   - spec.rules[*].validate.failureActionOverrides
-  - spec.rules[*].verifyImages[*].failureAction
+  - spec.rules[_].verifyImages[_].failureAction
   - spec.rules[*].mutate.mutateExisting
   - spec.rules[*].generate.generateExisting
 

--- a/src/content/blog/automating-cis-compliance/index.md
+++ b/src/content/blog/automating-cis-compliance/index.md
@@ -310,14 +310,15 @@ Based on extensive testing and development of the [cis-eks-kyverno](https://gith
 === CIS EKS Policy Test Results ===
 
 📊 Test Statistics
-| Metric | Value |
-|--------|-------|
-| Total Policies | 62 |
-| Total Tests | 62 |
-| ✅ Passed | 52 |
-| ❌ Failed | 8 |
-| ⏭️ Skipped | 2 |
-| Success Rate | 84% |
+
+| Metric         | Value |
+| -------------- | ----- |
+| Total Policies | 62    |
+| Total Tests    | 62    |
+| ✅ Passed      | 52    |
+| ❌ Failed      | 8     |
+| ⏭️ Skipped     | 2     |
+| Success Rate   | 84%   |
 
 📋 Policy Validation Results
 

--- a/src/content/docs/docs/policy-types/cluster-policy/external-data-sources.md
+++ b/src/content/docs/docs/policy-types/cluster-policy/external-data-sources.md
@@ -756,15 +756,9 @@ the output `imageData` variable will have a structure which looks like the follo
   "registry": "ghcr.io",
   "repository": "kyverno/kyverno",
   "identifier": "latest",
-  "manifestList": [
-    /* manifestList */
-  ],
-  "manifest": {
-    /* manifest */
-  },
-  "configData": {
-    /* config */
-  }
+  "manifestList": [/* manifestList */],
+  "manifest": {/* manifest */},
+  "configData": {/* config */}
 }
 ```
 

--- a/src/content/docs/docs/policy-types/generating-policy.mdx
+++ b/src/content/docs/docs/policy-types/generating-policy.mdx
@@ -120,6 +120,130 @@ spec:
 
 This policy is triggered whenever a Namespace is created. It captures the Namespace's name in `nsName` and defines the full ConfigMap object in `downstream`. Then, the `generator.Apply()` function creates the ConfigMap defined in `downstream` inside the target namespace.
 
+## YAML Templates
+
+<FeatureState state="beta" version="v1.19" />
+
+YAML templates provide an alternative, YAML-first way to declare downstream resources. Instead of constructing objects with nested CEL expressions and `dyn()` calls, you author the generated resources as plain YAML — optionally interpolated with CEL placeholders — directly in the `generate` entry.
+
+**When to Use:** Ideal when downstream resources are naturally manifest-shaped (NetworkPolicies, RoleBindings, LimitRanges, custom resources with deep nesting), and when migrating [generate rules](/docs/policy-types/cluster-policy/generate) that already declare resources as YAML.
+
+Each `generate[]` entry accepts exactly one of `expression` or `template`. Entries of both kinds may be mixed within the same policy.
+
+| Field                  | Description                                                                                                                                    |
+| :--------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------- |
+| `template.value`       | A YAML string containing one or more documents (separated by `---`), each describing a downstream resource.                                    |
+| `template.interpolate` | Controls placeholder evaluation: `none` (default) treats the value as plain YAML; `cel` evaluates `(( ... ))` placeholders as CEL expressions. |
+
+The following policy is equivalent to the Data Source example above, authored as a YAML template:
+
+```yaml
+apiVersion: policies.kyverno.io/v1
+kind: GeneratingPolicy
+metadata:
+  name: zk-kafka-address
+spec:
+  evaluation:
+    synchronize:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ['']
+        apiVersions: ['v1']
+        operations: ['CREATE']
+        resources: ['namespaces']
+  variables:
+    - name: nsName
+      expression: 'object.metadata.name'
+  generate:
+    - template:
+        interpolate: cel
+        value: |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: zk-kafka-address
+            namespace: (( variables.nsName ))
+          data:
+            KAFKA_ADDRESS: 192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092
+            ZK_ADDRESS: 192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181
+```
+
+The rendered documents flow through the same generation runtime as `generator.Apply()`, so synchronization, generating for existing resources, orphaning behavior, and namespace scope enforcement are identical to expression mode.
+
+### Placeholder Semantics
+
+Placeholders are evaluated against the same context as generation expressions (`object`, `variables`, and the [CEL libraries](/docs/policy-types/cel-libraries)). Interpolation is structural, not textual:
+
+- A placeholder occupying an **entire value** is spliced natively and may evaluate to any CEL type — including maps and lists. No `dyn()` conversions are required.
+- A placeholder **embedded in a larger string** is interpolated and must evaluate to a scalar (string, number, or boolean).
+
+```yaml
+variables:
+  - name: selector
+    expression: >-
+      {"matchLabels": {"kubernetes.io/metadata.name": object.metadata.name}}
+generate:
+  - template:
+      interpolate: cel
+      value: |
+        apiVersion: cilium.io/v2
+        kind: CiliumNetworkPolicy
+        metadata:
+          name: (( object.metadata.name ))-scraping   # embedded: string interpolation
+          namespace: (( object.metadata.name ))
+        spec:
+          endpointSelector: (( variables.selector ))  # whole value: full map spliced
+          ingress:
+          - toPorts:
+            - ports:
+              - port: (( string(variables.port) ))    # evaluated
+                protocol: TCP                         # static, kept as-is
+```
+
+Static and interpolated content can be mixed freely within the same mapping or list. Only placeholder nodes are evaluated; everything else passes through unchanged.
+
+::::note[Note]
+Placeholders are not supported in mapping keys. To produce dynamic keys, use a whole-value placeholder on the parent field instead, e.g. `labels: (( variables.labels ))`.
+::::
+
+To include a literal `((` in an interpolated template, escape it as `\((`. With `interpolate: none` (the default), placeholders are never evaluated and the value is parsed as plain YAML.
+
+### Generating Multiple Resources
+
+A single template may contain multiple YAML documents. Each document is generated independently, targeting the namespace in its own `metadata.namespace`:
+
+```yaml
+generate:
+  - template:
+      interpolate: cel
+      value: |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: (( variables.nsName ))-config
+          namespace: (( variables.nsName ))
+        data:
+          key: value
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: (( variables.nsName ))-secret
+          namespace: (( variables.nsName ))
+        type: Opaque
+        stringData:
+          password: change-me
+```
+
+### Namespace Targeting
+
+The target namespace of each generated resource is taken from its rendered `metadata.namespace`. Resources without a namespace are treated as cluster-scoped. For a NamespacedGeneratingPolicy, documents without a namespace default to the policy's own namespace, and any other namespace is rejected.
+
+::::note[Note]
+Generating the same resource into a runtime-computed set of namespaces (fan-out) is not expressible with templates; use expression mode with `generator.Apply()` inside a CEL loop for that pattern. See [Looping](#looping).
+::::
+
 ## Clone Source
 
 This mode copies an existing Kubernetes resource (the source) to create a new resource (the downstream). It makes use of `resource.Get()` or `resource.List()` to fetch source resources and clone them into the target namespace using `generator.Apply()`.

--- a/src/content/docs/docs/policy-types/image-validating-policy.mdx
+++ b/src/content/docs/docs/policy-types/image-validating-policy.mdx
@@ -145,6 +145,7 @@ spec:
               eyJzaWduZWQiOiB7Li4ufSwgInNpZ25hdHVyZXMiOiBbLi4uXX0=
           mirror: 'https://tuf.example.org' # Sigstore TUF mirror URL (optional)
 
+
   # ...
 ```
 


### PR DESCRIPTION
## Related issue / PR

Documents the YAML template mode for GeneratingPolicy proposed in kyverno/kyverno#16331 and implemented in kyverno/kyverno#16699 (API: kyverno/api#115), targeting Kyverno 1.19.

## Proposed Changes

Adds a new **YAML Templates** section to the GeneratingPolicy page (between *Data Source* and *Clone Source*), marked `beta v1.19`:

- Introduction and when-to-use guidance (YAML-first alternative to `dyn()`-heavy CEL object construction; migration path from ClusterPolicy generate rules); per-entry exclusivity of `expression` vs `template`
- Field reference for `template.value` and `template.interpolate` (`none` default / `cel`)
- A template-mode equivalent of the page's existing Data Source example, noting that rendered documents flow through the same generation runtime (synchronize / generateExisting / orphan / scope parity)
- **Placeholder Semantics**: structural whole-value splice vs embedded string interpolation, with an annotated CiliumNetworkPolicy snippet (LabelSelector map splice, mixed static/interpolated `toPorts`); mapping-key restriction with the dynamic-keys workaround; `\((` escaping; `interpolate: none` behavior
- **Generating Multiple Resources**: multi-document template example
- **Namespace Targeting**: per-document `metadata.namespace`, NamespacedGeneratingPolicy defaulting and cross-namespace denial, pointer to Looping for fan-out cases

Draft until kyverno/kyverno#16699 merges. Prettier-formatted; full `astro build` passes locally (762 pages).
