### PR TITLE
docs: fix broken CEL example in NamespacedImageValidatingPolicy

### DIFF
--- a/src/content/docs/docs/policy-types/image-validating-policy.mdx
+++ b/src/content/docs/docs/policy-types/image-validating-policy.mdx
@@ -145,7 +145,6 @@ spec:
               eyJzaWduZWQiOiB7Li4ufSwgInNpZ25hdHVyZXMiOiBbLi4uXX0=
           mirror: 'https://tuf.example.org' # Sigstore TUF mirror URL (optional)
 
-
   # ...
 ```
 
@@ -295,15 +294,16 @@ spec:
   matchImageReferences:
     - glob: 'ghcr.io/myorg/dev-*'
   attestors:
-    - name: dev-attestor
+    - name: devteam
       cosign:
         keyless:
           identities:
             - issuer: 'https://token.actions.githubusercontent.com'
               subject: '*@myorg.github.io'
   validations:
-    - message: 'image must be signed by the development team'
-      expression: 'imageverify.verify(images.containers, attestors.devAttestor).all(result, result.verified)'
+    - expression: >-
+        images.containers.map(image, verifyImageSignatures(image, [attestors.devteam])).all(e, e > 0)
+      message: 'image must be signed by the development team'
 ```
 
 The `NamespacedImageValidatingPolicy` allows namespace owners to manage image verification policies without requiring cluster-admin permissions. This enables development teams to enforce their own image security requirements, such as verifying images are signed by their CI/CD pipeline, without affecting other namespaces or requiring cluster-level access.

--- a/src/content/docs/docs/policy-types/image-validating-policy.mdx
+++ b/src/content/docs/docs/policy-types/image-validating-policy.mdx
@@ -468,7 +468,7 @@ spec:
   matchImageReferences:
     - glob: 'ghcr.io/myorg/dev-*'
   attestors:
-    - name: dev-attestor
+    - name: devteam
       cosign:
         keyless:
           identities:
@@ -476,7 +476,8 @@ spec:
               subject: '*@myorg.github.io'
   validations:
     - message: 'image must be signed by the development team'
-      expression: 'imageverify.verify(images.containers, attestors.devAttestor).all(result, result.verified)'
+      expression: >-
+        images.containers.map(image, verifyImageSignatures(image, [attestors.devteam])).all(e, e > 0)
 ```
 
 The `NamespacedImageValidatingPolicy` allows namespace owners to manage image verification policies without requiring cluster-admin permissions. This enables development teams to enforce their own image security requirements, such as verifying images are signed by their CI/CD pipeline, without affecting other namespaces or requiring cluster-level access.


### PR DESCRIPTION
## Related issue

Fixes #2094
Fixes #2095

## Proposed Changes

The `NamespacedImageValidatingPolicy` example used `imageverify.verify(...)`, which isn't a real function in the `imageverify` CEL library (only `verifyImageSignatures` and `verifyAttestationSignatures` are registered, see kyverno/kyverno's `pkg/cel/libs/imageverify/lib.go`). The example also named the attestor `dev-attestor` but referenced it as `attestors.devAttestor`, so the expression wouldn't resolve even after fixing the function name.

Renamed the attestor to `devteam` and replaced the expression with the `verifyImageSignatures` pattern already used elsewhere in this same doc, so both the function call and the attestor reference are valid and consistent.

Verified with `npm run build` (full site build, no errors) and `npx prettier --check` on the file.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.