### PR TITLE
docs: explain why custom CA secrets use type generic, not tls

### DIFF
--- a/src/content/docs/docs/installation/customization.md
+++ b/src/content/docs/docs/installation/customization.md
@@ -184,6 +184,10 @@ kubectl create secret generic kyverno-cleanup-controller.kyverno.svc.kyverno-tls
 
 Kyverno uses Secrets created above to setup TLS communication with the Kubernetes API server and specify the CA bundle to be used to validate the webhook server's certificate in the admission and cleanup webhook configurations.
 
+:::note[Note]
+The `-tls-pair` Secrets are created with type `kubernetes.io/tls` because Kyverno needs both the certificate and private key to serve TLS. The `-tls-ca` Secrets are created as type `generic` because only the CA certificate (`rootCA.crt`) is required to validate the chain; Kyverno reads this key directly and does not require (or need) the CA's private key to be stored in the cluster. This differs from Kyverno's own self-managed certificates (see [Default certificates](#default-certificates)), where all four Secrets, including the CA, are type `kubernetes.io/tls`, since Kyverno holds the CA private key itself in order to sign and rotate certificates automatically.
+:::
+
 ##### Install Kyverno
 
 You can now install Kyverno by selecting one of the available methods from the [installation section](/docs/installation/installation).


### PR DESCRIPTION
## Related issue

Fixes #1526

## Proposed Changes

The issue correctly points out that a default install's `kubectl get secret` output shows all four Kyverno-managed Secrets as `kubernetes.io/tls`, while the custom certificate instructions a few sections above create the two `-tls-ca` Secrets as `generic` — this looks inconsistent.

It isn't a bug though: Kyverno's own cert renewer (`pkg/tls/renewer.go`) always writes CA Secrets as `kubernetes.io/tls` because it holds the CA private key and needs to rotate it automatically. For a user-supplied CA, only the certificate is required to validate the chain — `decodeSecret()` explicitly falls back to reading the `rootCA.crt` key from a plain `generic` Secret, and no private key is needed. Switching the custom-cert instructions to `kubernetes.io/tls` would actually require storing the CA's private key in the cluster, which most custom-CA setups (deliberately) don't want to do.

Added a short note explaining the distinction instead of changing the type, so this doesn't look like an unresolved inconsistency to the next reader.

Verified with `npm run build` (full site build, no errors) and `npx prettier --check` on the file.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [x] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.