### PR TITLE
docs: document kyverno.io/v2beta1 deprecation warnings and migration …

### DIFF
--- a/src/content/blog/announcing-kyverno-release-1.19/index.md
+++ b/src/content/blog/announcing-kyverno-release-1.19/index.md
@@ -26,6 +26,8 @@ Kyverno 1.19 delivers:
 
 - CRDs now managed through a dedicated **kyverno-api Helm chart** dependency
 
+- **Proactive deprecation warnings** for the older `kyverno.io/v2beta1` and `kyverno.io/v2alpha1` API versions of `ClusterPolicy`, `Policy`, `PolicyException`, `CleanupPolicy`, `ClusterCleanupPolicy`, and `GlobalContextEntry` — emitted via admission `warnings`, the Kyverno CLI, and the new `kyverno_deprecated_api_requests_total` metric. The CLI also gains a `--warnings-as-errors` flag to fail CI on deprecations.
+
 If you are still using `ClusterPolicy`, **now is the time to migrate**. v1.19 is the final release with full support for the legacy policy types.
 
 ## **CEL Policy Feature Parity**

--- a/src/content/docs/docs/installation/upgrading.md
+++ b/src/content/docs/docs/installation/upgrading.md
@@ -75,12 +75,12 @@ The `kyverno.io/v2beta1` schemas for `ClusterPolicy`, `Policy`, `PolicyException
 
 2. Update each manifest's `apiVersion`:
 
-   | Kind                                    | From                  | To                 |
-   | --------------------------------------- | --------------------- | ------------------ |
-   | `ClusterPolicy`, `Policy`               | `kyverno.io/v2beta1`  | `kyverno.io/v1`    |
-   | `PolicyException`                       | `kyverno.io/v2beta1`  | `kyverno.io/v2`    |
-   | `CleanupPolicy`, `ClusterCleanupPolicy` | `kyverno.io/v2beta1`  | `kyverno.io/v2`    |
-   | `GlobalContextEntry`                    | `kyverno.io/v2alpha1` | `kyverno.io/v2`    |
+   | Kind                                    | From                  | To              |
+   | --------------------------------------- | --------------------- | --------------- |
+   | `ClusterPolicy`, `Policy`               | `kyverno.io/v2beta1`  | `kyverno.io/v1` |
+   | `PolicyException`                       | `kyverno.io/v2beta1`  | `kyverno.io/v2` |
+   | `CleanupPolicy`, `ClusterCleanupPolicy` | `kyverno.io/v2beta1`  | `kyverno.io/v2` |
+   | `GlobalContextEntry`                    | `kyverno.io/v2alpha1` | `kyverno.io/v2` |
 
 3. Re-apply the updated manifests. No `spec` changes are required.
 

--- a/src/content/docs/docs/installation/upgrading.md
+++ b/src/content/docs/docs/installation/upgrading.md
@@ -29,6 +29,7 @@ Kyverno v1.19 achieves full feature parity between the CEL-based policy types in
 2. **`CleanupPolicy` and `ClusterCleanupPolicy` (`kyverno.io/v2`)** are deprecated and will be **removed in v1.20**. Use [DeletingPolicy](/docs/policy-types/deleting-policy) instead.
 3. **The legacy PolicyException (`kyverno.io/v2`)** is deprecated and will be **removed in v1.20**. Use the [`policies.kyverno.io` PolicyException](/docs/guides/exceptions) instead.
 4. **The `v1alpha1` versions of the `policies.kyverno.io` policy types are deprecated.** Update your manifests to use `policies.kyverno.io/v1`.
+5. **The `kyverno.io/v2beta1` API versions of `ClusterPolicy`, `Policy`, `PolicyException`, `CleanupPolicy`, and `ClusterCleanupPolicy` now emit deprecation warnings when used.** These versions remain fully served in v1.19 (non-breaking), but should be migrated to `kyverno.io/v1` (`ClusterPolicy`/`Policy`) or `kyverno.io/v2` (the others) ahead of their future removal. See [Migrating from v2beta1](#migrating-from-v2beta1).
 
 The following resource types are **not** deprecated and continue to be fully supported with CEL-based policies:
 
@@ -51,6 +52,41 @@ Starting with v1.19, the Kyverno CRDs are managed through a dedicated `kyverno-a
 ### CLI Changes
 
 The experimental `kyverno json scan` command has been removed from the Kyverno CLI in v1.19. To validate JSON payloads, use [ValidatingPolicy](/docs/policy-types/validating-policy) with the [`kyverno apply`](/docs/kyverno-cli/reference/kyverno_apply) command, or the [kyverno-json](https://kyverno.github.io/kyverno-json/) subproject directly.
+
+### Deprecation Warnings
+
+Starting in v1.19, Kyverno surfaces API and field deprecations proactively so clusters can inventory and migrate usage before removal:
+
+- **Admission webhooks**: creating or updating a resource that uses a deprecated API version or field returns a Kubernetes `warnings` entry in the admission response.
+- **Kyverno CLI**: `kubectl-kyverno apply` and `kubectl-kyverno test` print warnings such as `Warning: <file>: <message>` for deprecated versions and fields.
+- **`--warnings-as-errors`**: the CLI exposes a root-level `--warnings-as-errors` flag (applies to `apply` and `test`). When set, any detected deprecation causes the command to exit non-zero, making it easy to gate CI pipelines on deprecations.
+- **Metrics**: Kyverno increments the `kyverno_deprecated_api_requests_total{group,version,kind,field}` counter for each deprecated API request. The `field` label is the deprecated field path (empty for version-level deprecations). Use this metric to track adoption of deprecated versions across your clusters.
+
+### Migrating from v2beta1
+
+The `kyverno.io/v2beta1` schemas for `ClusterPolicy`, `Policy`, `PolicyException`, `CleanupPolicy`, and `ClusterCleanupPolicy` are identical to their `kyverno.io/v1` / `kyverno.io/v2` equivalents, so migration is a simple API version swap:
+
+1. Find resources still using the deprecated versions:
+
+   ```sh
+   kubectl get clusterpolicies,policies,policyexceptions,cleanuppolicies,clustercleanuppolicies -A \
+     -o custom-columns='KIND:.kind,NAME:.metadata.name,NS:.metadata.namespace,VER:.apiVersion'
+   ```
+
+2. Update each manifest's `apiVersion`:
+
+   | Kind                                    | From                  | To                 |
+   | --------------------------------------- | --------------------- | ------------------ |
+   | `ClusterPolicy`, `Policy`               | `kyverno.io/v2beta1`  | `kyverno.io/v1`    |
+   | `PolicyException`                       | `kyverno.io/v2beta1`  | `kyverno.io/v2`    |
+   | `CleanupPolicy`, `ClusterCleanupPolicy` | `kyverno.io/v2beta1`  | `kyverno.io/v2`    |
+   | `GlobalContextEntry`                    | `kyverno.io/v2alpha1` | `kyverno.io/v2`    |
+
+3. Re-apply the updated manifests. No `spec` changes are required.
+
+:::note
+These deprecations are independent of the separate [CEL migration](/docs/guides/migration-to-cel) of the legacy policy types (`kyverno.io/v1` → `policies.kyverno.io/v1`). Migrating `v2beta1` → `v1` is only the first step; consider migrating to the CEL-based types for the long term.
+:::
 
 ## Upgrading to Kyverno v1.13
 

--- a/src/content/docs/docs/policy-types/overview.md
+++ b/src/content/docs/docs/policy-types/overview.md
@@ -48,14 +48,14 @@ The legacy `PolicyException` in the `kyverno.io` API group is deprecated togethe
 
 Independent of resource deprecation, older API _versions_ of retained resources are deprecated and rotate out following normal Kubernetes API version deprecation. The resources themselves are not going away — only re-apply your manifests with the newer API version:
 
-| Resource                               | Deprecated Version                | Use Instead     |
-| -------------------------------------- | --------------------------------- | --------------- |
-| All `policies.kyverno.io` policy types | `v1alpha1`                        | `v1`            |
-| `ClusterPolicy` / `Policy`             | `kyverno.io/v2beta1`              | `kyverno.io/v1` |
-| `PolicyException`                      | `kyverno.io/v2beta1`              | `kyverno.io/v2` |
-| `CleanupPolicy` / `ClusterCleanupPolicy` | `kyverno.io/v2beta1`           | `kyverno.io/v2` |
-| GlobalContextEntry                     | `kyverno.io/v2alpha1`             | `kyverno.io/v2` |
-| UpdateRequest                          | `kyverno.io/v1beta1` (not served) | `kyverno.io/v2` |
+| Resource                                 | Deprecated Version                | Use Instead     |
+| ---------------------------------------- | --------------------------------- | --------------- |
+| All `policies.kyverno.io` policy types   | `v1alpha1`                        | `v1`            |
+| `ClusterPolicy` / `Policy`               | `kyverno.io/v2beta1`              | `kyverno.io/v1` |
+| `PolicyException`                        | `kyverno.io/v2beta1`              | `kyverno.io/v2` |
+| `CleanupPolicy` / `ClusterCleanupPolicy` | `kyverno.io/v2beta1`              | `kyverno.io/v2` |
+| GlobalContextEntry                       | `kyverno.io/v2alpha1`             | `kyverno.io/v2` |
+| UpdateRequest                            | `kyverno.io/v1beta1` (not served) | `kyverno.io/v2` |
 
 :::note[Deprecation warnings (v1.19+)]
 Starting in Kyverno v1.19, resources still using the `kyverno.io/v2beta1` and `kyverno.io/v2alpha1` API versions emit **deprecation warnings** (via the admission `warnings` field and the Kyverno CLI). These versions remain fully served in v1.19 — the warnings are non-breaking and give you time to migrate before removal. See [Migrating from v2beta1](/docs/installation/upgrading#migrating-from-v2beta1).

--- a/src/content/docs/docs/policy-types/overview.md
+++ b/src/content/docs/docs/policy-types/overview.md
@@ -51,8 +51,15 @@ Independent of resource deprecation, older API _versions_ of retained resources 
 | Resource                               | Deprecated Version                | Use Instead     |
 | -------------------------------------- | --------------------------------- | --------------- |
 | All `policies.kyverno.io` policy types | `v1alpha1`                        | `v1`            |
+| `ClusterPolicy` / `Policy`             | `kyverno.io/v2beta1`              | `kyverno.io/v1` |
+| `PolicyException`                      | `kyverno.io/v2beta1`              | `kyverno.io/v2` |
+| `CleanupPolicy` / `ClusterCleanupPolicy` | `kyverno.io/v2beta1`           | `kyverno.io/v2` |
 | GlobalContextEntry                     | `kyverno.io/v2alpha1`             | `kyverno.io/v2` |
 | UpdateRequest                          | `kyverno.io/v1beta1` (not served) | `kyverno.io/v2` |
+
+:::note[Deprecation warnings (v1.19+)]
+Starting in Kyverno v1.19, resources still using the `kyverno.io/v2beta1` and `kyverno.io/v2alpha1` API versions emit **deprecation warnings** (via the admission `warnings` field and the Kyverno CLI). These versions remain fully served in v1.19 — the warnings are non-breaking and give you time to migrate before removal. See [Migrating from v2beta1](/docs/installation/upgrading#migrating-from-v2beta1).
+:::
 
 :::note[Storage Version]
 In v1.19, the storage version for the `policies.kyverno.io` types remains `v1beta1`. It will move to `v1` in v1.20. After upgrading, the [`kyverno migrate`](/docs/kyverno-cli/reference/kyverno_migrate) CLI command can be used to rewrite stored objects to the current storage version.


### PR DESCRIPTION
## Description

Documentation for the `kyverno.io/v2beta1` / `kyverno.io/v2alpha1` deprecation warnings introduced in Kyverno v1.19 (code change in kyverno/kyverno#17225, Phase 1 — non-breaking).

This PR:
- Adds the `kyverno.io/v2beta1` rows (`ClusterPolicy`/`Policy` → `v1`, `PolicyException`/`CleanupPolicy`/`ClusterCleanupPolicy` → `v2`) to the **Deprecated API Versions** table in the policy types overview, alongside the existing `v2alpha1` GlobalContextEntry entry.
- Documents the new **deprecation warning** behavior in the v1.19 upgrade guide: admission `warnings`, Kyverno CLI warnings, the new `--warnings-as-errors` CLI flag, and the `kyverno_deprecated_api_requests_total{group,version,kind,field}` metric.
- Adds a **Migrating from v2beta1** guide (find resources → swap `apiVersion` → re-apply; no `spec` changes) and clarifies this is separate from the CEL migration (`kyverno.io/v1` → `policies.kyverno.io/v1`).
- Adds a release-notes bullet to the Kyverno 1.19 announcement blog.

These versions remain fully served in v1.19; the changes are warnings only, giving users time to migrate before future removal.

## Related issues

Documents [kyverno/kyverno#17225](https://github.com/kyverno/kyverno/pull/17231)

## Checklist

- [x] I have read the contributor guidelines.
- [x] I have verified links and Markdown render correctly.
- [ ] I have confirmed the preview build passes (docs site).