### PR TITLE
fix: use npm instead of yarn in lint workflow for consistency

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,6 +26,6 @@ jobs:
           node-version: 24
           cache: npm
       - name: Install dependencies
-        run: yarn install --immutable
+        run: npm ci
       - name: Run Prettier
-        run: yarn format:check
+        run: npm run format:check

--- a/src/components/FeatureState.astro
+++ b/src/components/FeatureState.astro
@@ -6,7 +6,10 @@ interface Props {
 
 const { state, version } = Astro.props
 const normalizedState = (state?.toLowerCase() || 'beta') as
-  'alpha' | 'beta' | 'stable' | 'deprecated'
+  | 'alpha'
+  | 'beta'
+  | 'stable'
+  | 'deprecated'
 
 // State configuration with colors and labels
 const stateConfig = {

--- a/src/content/docs/docs/policy-types/cluster-policy/external-data-sources.md
+++ b/src/content/docs/docs/policy-types/cluster-policy/external-data-sources.md
@@ -756,9 +756,15 @@ the output `imageData` variable will have a structure which looks like the follo
   "registry": "ghcr.io",
   "repository": "kyverno/kyverno",
   "identifier": "latest",
-  "manifestList": [/* manifestList */],
-  "manifest": {/* manifest */},
-  "configData": {/* config */}
+  "manifestList": [
+    /* manifestList */
+  ],
+  "manifest": {
+    /* manifest */
+  },
+  "configData": {
+    /* config */
+  }
 }
 ```
 

--- a/src/content/docs/docs/policy-types/image-validating-policy.mdx
+++ b/src/content/docs/docs/policy-types/image-validating-policy.mdx
@@ -147,7 +147,6 @@ spec:
               eyJzaWduZWQiOiB7Li4ufSwgInNpZ25hdHVyZXMiOiBbLi4uXX0=
           mirror: 'https://tuf.example.org' # Sigstore TUF mirror URL (optional)
 
-
   # ...
 ```
 


### PR DESCRIPTION
The CI workflow was using yarn install with --immutable flag, but the project only has package-lock.json (npm's lock file), not yarn.lock.

This caused version mismatches:
- **Local**: uses npm with package-lock.json (prettier 3.7.4)
- **CI**: uses yarn install (could install different version in ^3.6.2 range)

**Changes:**
- Updated lint.yaml to use `npm ci` instead of `yarn install --immutable`
- Updated prettier check to use `npm run` instead of `yarn`

This ensures:
- Consistent prettier version between local and CI
- Respects locked versions in package-lock.json
- Aligns with the npm-based package management in package-lock.json