### PR TITLE
fix: use GitHub App auth for cherry-pick workflows

### DIFF
--- a/.github/actions/cherry-pick/action.yaml
+++ b/.github/actions/cherry-pick/action.yaml
@@ -39,7 +39,12 @@ runs:
         sudo apt install gh -y
     - name: Authenticate gh
       shell: bash
-      run: gh auth setup-git
+      run: |
+        if [ -z "$GH_TOKEN" ]; then
+          echo "::error::github-token input is empty, check the workflow secrets configuration"
+          exit 1
+        fi
+        gh auth setup-git
       env:
         GH_TOKEN: ${{ inputs.github-token }}
 

--- a/.github/workflows/cherry-pick-on-merge.yaml
+++ b/.github/workflows/cherry-pick-on-merge.yaml
@@ -44,11 +44,60 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Normalize GitHub App private key
+        if: steps.cherry.outputs.result != '[]'
+        id: normalize-key
+        shell: bash
+        env:
+          RAW_APP_PRIVATE_KEY: ${{ secrets.PR_UPDATER_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          key="$RAW_APP_PRIVATE_KEY"
+          # Support secrets saved with escaped newlines.
+          key="${key//\\n/$'\n'}"
+
+          if ! printf '%s' "$key" | grep -Eq 'BEGIN (RSA |EC |)PRIVATE KEY'; then
+            # Support secrets saved as base64-encoded PEM.
+            decoded="$(printf '%s' "$RAW_APP_PRIVATE_KEY" | tr -d '[:space:]' | base64 --decode 2>/dev/null || true)"
+            decoded="${decoded//\\n/$'\n'}"
+            if printf '%s' "$decoded" | grep -Eq 'BEGIN (RSA |EC |)PRIVATE KEY'; then
+              key="$decoded"
+            fi
+          fi
+
+          if ! printf '%s' "$key" | grep -Eq 'BEGIN (RSA |EC |)PRIVATE KEY'; then
+            echo "PR_UPDATER_APP_PRIVATE_KEY does not look like a valid PEM private key." >&2
+            exit 1
+          fi
+
+          # ::add-mask:: is line-based, mask each line of the key individually.
+          while IFS= read -r line; do
+            [ -n "$line" ] && echo "::add-mask::$line"
+          done <<< "$key"
+          {
+            echo "private_key<<EOF"
+            printf '%s\n' "$key"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub App token
+        if: steps.cherry.outputs.result != '[]'
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.PR_UPDATER_APP_CLIENT_ID }}
+          private-key: ${{ steps.normalize-key.outputs.private_key }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Cherry-pick to each branch
         if: steps.cherry.outputs.result != '[]'
         uses: ./.github/actions/cherry-pick
         with:
-          github-token: ${{ secrets.PR_UPDATE_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           source-pr: ${{ github.event.pull_request.number }}
           source-pr-title: ${{ github.event.pull_request.title }}
           target-branches: ${{ fromJSON(steps.cherry.outputs.result)[0] }}

--- a/.github/workflows/comment-commands.yaml
+++ b/.github/workflows/comment-commands.yaml
@@ -43,6 +43,53 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           reaction: '+1'
 
+      - name: Normalize GitHub App private key
+        id: normalize-key
+        shell: bash
+        env:
+          RAW_APP_PRIVATE_KEY: ${{ secrets.PR_UPDATER_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          key="$RAW_APP_PRIVATE_KEY"
+          # Support secrets saved with escaped newlines.
+          key="${key//\\n/$'\n'}"
+
+          if ! printf '%s' "$key" | grep -Eq 'BEGIN (RSA |EC |)PRIVATE KEY'; then
+            # Support secrets saved as base64-encoded PEM.
+            decoded="$(printf '%s' "$RAW_APP_PRIVATE_KEY" | tr -d '[:space:]' | base64 --decode 2>/dev/null || true)"
+            decoded="${decoded//\\n/$'\n'}"
+            if printf '%s' "$decoded" | grep -Eq 'BEGIN (RSA |EC |)PRIVATE KEY'; then
+              key="$decoded"
+            fi
+          fi
+
+          if ! printf '%s' "$key" | grep -Eq 'BEGIN (RSA |EC |)PRIVATE KEY'; then
+            echo "PR_UPDATER_APP_PRIVATE_KEY does not look like a valid PEM private key." >&2
+            exit 1
+          fi
+
+          # ::add-mask:: is line-based, mask each line of the key individually.
+          while IFS= read -r line; do
+            [ -n "$line" ] && echo "::add-mask::$line"
+          done <<< "$key"
+          {
+            echo "private_key<<EOF"
+            printf '%s\n' "$key"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.PR_UPDATER_APP_CLIENT_ID }}
+          private-key: ${{ steps.normalize-key.outputs.private_key }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Check if PR is merged
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: check-merged
@@ -88,7 +135,7 @@ jobs:
         if: ${{ fromJSON(steps.check-merged.outputs.result).merged == false && fromJSON(steps.check-merged.outputs.result).state != 'closed' }}
         uses: ben-z/actions-comment-on-issue@402eb412a8f396be0d4ac52a823ec7121206cc26 # v1.0.3
         with:
-          GITHUB_TOKEN: ${{ secrets.PR_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           message: |
             Commits from this PR will automatically be cherry-picked once this PR gets merged.
 
@@ -104,7 +151,7 @@ jobs:
         continue-on-error: true # Send failure comment to PR
         id: cherry-pick
         with:
-          github-token: ${{ secrets.PR_UPDATE_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           source-pr: ${{ github.event.issue.number }}
           source-pr-title: ${{ github.event.issue.title }}
           target-branches: ${{ steps.extract-branch.outputs.branch }}
@@ -114,7 +161,7 @@ jobs:
         if: ${{ steps.cherry-pick.outputs.success == false && fromJSON(steps.check-merged.outputs.result).merged == true }}
         uses: ben-z/actions-comment-on-issue@402eb412a8f396be0d4ac52a823ec7121206cc26 # v1.0.3
         with:
-          GITHUB_TOKEN: ${{ secrets.PR_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           message: |
             :no_entry_sign: Cherry picking merge commit `${{ fromJSON(steps.check-merged.outputs.result).mergeCommit}}` failed. 
 


### PR DESCRIPTION
## Problem

The cherry-pick bot is broken — see the failed `/cherry-pick release-1-19-0` on #2129 and failing [cherry-pick-on-merge runs](https://github.com/kyverno/website/actions/workflows/cherry-pick-on-merge.yaml) ("You are not logged into any GitHub hosts" / "Bad credentials").

Root cause: the workflows still reference `secrets.PR_UPDATE_TOKEN`, an org PAT that was removed when kyverno/kyverno migrated to GitHub App auth (kyverno/kyverno#16662). The secret now resolves to an empty string.

## Fix

Ports kyverno/kyverno#16967 + kyverno/kyverno#16968 to this repo:

- Mint an installation token via `actions/create-github-app-token` (pinned v3.2.0) using the PR updater GitHub App, requesting only `contents: write` + `pull-requests: write` (the App installation does not grant Issues permission — requesting it fails token minting, see kyverno/kyverno#16968).
- Add a "Normalize GitHub App private key" step that tolerates secrets stored with escaped newlines or as base64 PEM, and masks every key line in logs.
- Replace all `secrets.PR_UPDATE_TOKEN` references with the minted App token in `comment-commands.yaml` and `cherry-pick-on-merge.yaml`.
- Fail fast in `.github/actions/cherry-pick` with a clear error if the token input is empty.

## ⚠️ Org-admin prerequisites (please verify before merging)

1. The org secrets `PR_UPDATER_APP_CLIENT_ID` and `PR_UPDATER_APP_PRIVATE_KEY` must be **visible to kyverno/website** (they may currently be scoped to kyverno/kyverno only).
2. The PR updater GitHub App must be **installed on kyverno/website** with Contents + Pull requests write permissions.

I could not verify either (requires org admin).

## Testing

After merge, re-trigger the stuck cherry-pick by editing or re-posting `/cherry-pick release-1-19-0` on #2129 (the workflow triggers on comment `created` and `edited`).