### PR TITLE
publish 1.19 release blog post (main)

### DIFF
--- a/src/content/blog/announcing-kyverno-release-1.19/index.md
+++ b/src/content/blog/announcing-kyverno-release-1.19/index.md
@@ -1,10 +1,10 @@
 ---
-date: 2026-08-18
+date: 2026-08-20
 title: Announcing Kyverno 1.19!
 tags:
   - Releases
 excerpt: Full feature parity for CEL-based policies and the official deprecation of ClusterPolicy in Kyverno 1.19
-draft: true
+draft: false
 featured: true
 ---
 


### PR DESCRIPTION
Same as the `release-1-19-0` publish PR: flips `draft: false` and sets the publish date to GA day (2026-08-20) so the 1.19 announcement appears on the blog index on `main` / main.kyverno.io.