### PR TITLE
docs: admission replicas do not shard the in-memory policy cache

### DIFF
--- a/src/content/docs/docs/guides/high-availability.md
+++ b/src/content/docs/docs/guides/high-availability.md
@@ -55,7 +55,7 @@ The Admission Controller is a required component of any Kyverno installation reg
 
 The admission controller does not use leader election for inbound webhook requests which means AdmissionReview requests can be distributed and processed by all available replicas. The minimum supported replica count for a highly-available admission controller deployment is three. Leader election is required for certificate and webhook management functions so therefore only one replica will handle these tasks at a given time.
 
-Multiple replicas configured for the admission controller can be used for both availability and scale. Vertical scaling of the individual replicas' resources may also be performed to increase combined throughput.
+Multiple replicas configured for the admission controller can be used for both availability and scale of AdmissionReview processing. They do not shard the in-memory policy cache: every replica loads the full policy set. Vertical scaling of the individual replicas' resources may also be performed to increase combined throughput and to hold a large policy cache. See [Scaling Kyverno](/docs/installation/scaling#horizontal-scale) for how this interacts with policy count.
 
 ### Reports Controller
 

--- a/src/content/docs/docs/installation/scaling.md
+++ b/src/content/docs/docs/installation/scaling.md
@@ -25,6 +25,8 @@ We recommend conducting tests in your own environment to determine real-world ut
 
 Horizontal scaling refers to increasing the number of replicas of a given controller. Kyverno supports multiple replicas for each of its controllers, but the effect of multiple replicas is handled differently according to the controller. See the [high availability section](/docs/guides/high-availability#how-ha-works-in-kyverno) for more details.
 
+Admission controller replicas share AdmissionReview request load. They do not partition the policy set. Each replica watches every `Policy` and `ClusterPolicy` and keeps a full in-memory policy cache, so per-pod memory grows with policy count rather than shrinking as replicas are added. Size admission memory for the number of policies in the cluster, and add replicas for webhook throughput and availability. Count active policies with `kyverno_policy_rule_info_total` (see the [metrics reference](/docs/reference/metrics#policies-and-rules-count)). Prefer fewer, broader policies (for example one `ClusterPolicy` plus [Global Context](/docs/policy-types/global-context-caching)) over thousands of near-identical namespaced `Policy` resources.
+
 ### Scale Testing
 
 #### Admission Controller
@@ -113,3 +115,5 @@ In clusters with many Kyverno policy resources, the resource footprint of some c
 
 For example, if you create several thousand Kyverno policy resources, double check that the kube-apiserver pods have head room to increase its memory allocations, otherwise
 the cluster may crash entirely.
+
+Admission controller pods are affected as well. Because the policy cache is not sharded across replicas, a large `Policy`/`ClusterPolicy` count raises RSS on every admission replica. With the webhook `failurePolicy` set to `Fail`, losing every replica to OOM blocks matching admission cluster-wide until a replica recovers.


### PR DESCRIPTION
Fixes https://github.com/kyverno/website/issues/2146

Admission-controller replicas share AdmissionReview QPS. They do not partition Policy/ClusterPolicy. Each replica keeps a full in-memory cache, so per-pod memory grows with policy count.

This states that on the scaling and high-availability pages, points at `kyverno_policy_rule_info_total` for counting policies, and notes the Fail-closed OOM case when every replica is down.
