### PR TITLE
docs: document phase 1 legacy API deprecation warnings and tooling

### DIFF
--- a/src/content/docs/docs/guides/migration-to-cel.md
+++ b/src/content/docs/docs/guides/migration-to-cel.md
@@ -313,7 +313,7 @@ Warning: spec.validationFailureAction: Validation failure actions enforce/audit 
 
 **CLI Warnings**
 
-The [`kyverno apply`](/docs/kyverno-cli/reference/kyverno_apply) and [`kyverno test`](/docs/kyverno-cli/reference/kyverno_test) commands print the same deprecation warnings when loading legacy policies or policy exceptions. To enforce migration in CI pipelines, add the `--warnings-as-errors` flag to make these commands fail when any deprecation warning is found:
+The [`kyverno apply`](/docs/kyverno-cli/reference/kyverno_apply) and [`kyverno test`](/docs/kyverno-cli/reference/kyverno_test) commands print the same kind-level deprecation warnings when loading legacy policies or policy exceptions (field-level warnings are only emitted by the admission controller). To enforce migration in CI pipelines, add the `--warnings-as-errors` flag to make these commands fail when any deprecation warning is found:
 
 ```bash
 kyverno apply /path/to/policy.yaml --resource /path/to/resource.yaml --warnings-as-errors

--- a/src/content/docs/docs/guides/migration-to-cel.md
+++ b/src/content/docs/docs/guides/migration-to-cel.md
@@ -293,6 +293,37 @@ If you have existing [Kyverno CLI tests](/docs/kyverno-cli/reference/kyverno_tes
 
 If you have existing [Kyverno Chainsaw](/docs/subprojects/chainsaw/) tests, any policy type and status checks will need to be converted. The rest of the test logic can be reused.
 
+## Detecting Legacy Policy Usage
+
+Starting with Kyverno v1.19, the admission controller and the Kyverno CLI emit deprecation warnings to help you find remaining legacy policies before they are removed.
+
+**Admission Warnings**
+
+When a legacy `kyverno.io` policy type is created or updated, the response includes a warning identifying the replacement type:
+
+```
+Warning: kyverno.io/v1 ClusterPolicy is deprecated and will be removed in a future release; migrate to ValidatingPolicy, MutatingPolicy, GeneratingPolicy or ImageValidatingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
+```
+
+Warnings are also returned for deprecated field values, such as the lowercase `enforce`/`audit` validation failure actions:
+
+```
+Warning: spec.validationFailureAction: Validation failure actions enforce/audit are deprecated, use Enforce/Audit instead.
+```
+
+**CLI Warnings**
+
+The [`kyverno apply`](/docs/kyverno-cli/reference/kyverno_apply) and [`kyverno test`](/docs/kyverno-cli/reference/kyverno_test) commands print the same deprecation warnings when loading legacy policies or policy exceptions. To enforce migration in CI pipelines, add the `--warnings-as-errors` flag to make these commands fail when any deprecation warning is found:
+
+```bash
+kyverno apply /path/to/policy.yaml --resource /path/to/resource.yaml --warnings-as-errors
+kyverno test . --warnings-as-errors
+```
+
+**Tracking Usage with Metrics**
+
+The `kyverno_deprecated_api_requests_total` counter, labeled by `group`, `version`, `kind`, and `field`, tracks admission requests that use deprecated policy types or fields. Use it to confirm that nothing in the cluster still creates or updates legacy policies before upgrading. See the [metrics reference](/docs/reference/metrics#deprecated-api-requests-count) for details and example queries.
+
 ## Troubleshooting
 
 **CEL Expression Errors**

--- a/src/content/docs/docs/kyverno-cli/reference/kyverno_apply.md
+++ b/src/content/docs/docs/kyverno-cli/reference/kyverno_apply.md
@@ -85,6 +85,7 @@ kyverno apply [flags]
   -f, --values-file string                 File containing values for policy variables
       --warn-exit-code int                 Set the exit code for warnings; if failures or errors are found, will exit 1
       --warn-no-pass                       Specify if warning exit code should be raised if no objects satisfied a policy; can be used together with --warn-exit-code flag
+      --warnings-as-errors                 Treat deprecation warnings as errors
 ```
 
 ### Options inherited from parent commands

--- a/src/content/docs/docs/kyverno-cli/reference/kyverno_test.md
+++ b/src/content/docs/docs/kyverno-cli/reference/kyverno_test.md
@@ -47,6 +47,7 @@ kyverno test [local folder or git repository]... [flags]
       --remove-color                Remove any color from output
       --require-tests               If set to true, return an error if no tests are found
   -t, --test-case-selector string   Filter test cases to run (default "policy=*,rule=*,resource=*")
+      --warnings-as-errors          Treat deprecation warnings as errors
 ```
 
 ### Options inherited from parent commands

--- a/src/content/docs/docs/policy-types/overview.md
+++ b/src/content/docs/docs/policy-types/overview.md
@@ -69,4 +69,4 @@ The `ClusterPolicy`, `Policy`, and `CleanupPolicy` types, and the legacy `kyvern
 | v1.19   | Aug 2026             | **Officially deprecated — final release with full support** |
 | v1.20   | Nov 2026 (estimated) | **Removed**                                                 |
 
-As of v1.19, creating or updating a legacy policy type returns an admission warning, and the `kyverno_deprecated_api_requests_total` metric tracks deprecated API usage. The Kyverno CLI prints the same warnings and supports a `--warnings-as-errors` flag for CI enforcement. See [Detecting Legacy Policy Usage](/docs/guides/migration-to-cel#detecting-legacy-policy-usage) in the migration guide.
+As of v1.19, creating or updating a legacy policy type returns an admission warning, and the `kyverno_deprecated_api_requests_total` metric tracks deprecated API usage. The Kyverno CLI prints the same kind-level warnings and supports a `--warnings-as-errors` flag for CI enforcement. See [Detecting Legacy Policy Usage](/docs/guides/migration-to-cel#detecting-legacy-policy-usage) in the migration guide.

--- a/src/content/docs/docs/policy-types/overview.md
+++ b/src/content/docs/docs/policy-types/overview.md
@@ -68,3 +68,5 @@ The `ClusterPolicy`, `Policy`, and `CleanupPolicy` types, and the legacy `kyvern
 | v1.18   | Apr 2026             | Critical fixes only                                         |
 | v1.19   | Aug 2026             | **Officially deprecated — final release with full support** |
 | v1.20   | Nov 2026 (estimated) | **Removed**                                                 |
+
+As of v1.19, creating or updating a legacy policy type returns an admission warning, and the `kyverno_deprecated_api_requests_total` metric tracks deprecated API usage. The Kyverno CLI prints the same warnings and supports a `--warnings-as-errors` flag for CI enforcement. See [Detecting Legacy Policy Usage](/docs/guides/migration-to-cel#detecting-legacy-policy-usage) in the migration guide.

--- a/src/content/docs/docs/reference/metrics.md
+++ b/src/content/docs/docs/reference/metrics.md
@@ -589,6 +589,40 @@ See [Prometheus docs](https://prometheus.io/docs/practices/histograms/) for a de
 
 ---
 
+### Deprecated API Requests Count
+
+#### Metric Name(s)
+
+- `kyverno_deprecated_api_requests_total`
+
+#### Metric Value
+
+Counter - An only-increasing integer representing the count of admission requests that used deprecated Kyverno policy APIs or deprecated fields.
+
+#### Metric Labels
+
+| Label   | Allowed Values                                                              | Description                                                                                                                               |
+| ------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| group   | "kyverno.io"                                                                | API group of the deprecated resource                                                                                                      |
+| version | "v1", "v2", "v2beta1", etc.                                                 | API version of the deprecated resource                                                                                                    |
+| kind    | "ClusterPolicy", "Policy", "CleanupPolicy", "PolicyException", etc.         | Kind of the deprecated resource                                                                                                           |
+| field   | "spec.validationFailureAction", "spec.rules[].validate.failureAction", etc. | Normalized path of the deprecated field that was used. Empty when the request is counted for using a deprecated kind rather than a field. |
+
+#### Use cases
+
+- The cluster admin wants to verify that no workloads or pipelines are still creating or updating legacy `kyverno.io` policy types before upgrading to a release that removes them.
+- The cluster admin wants to find policies that still use deprecated field values, such as the lowercase `enforce`/`audit` validation failure actions.
+
+#### Useful Queries
+
+- Deprecated API requests seen in the last 7 days, grouped by kind and version:<br>
+  `sum(increase(kyverno_deprecated_api_requests_total{}[7d])) by (kind, version)`
+
+- Requests using deprecated fields, grouped by kind and field:<br>
+  `sum(kyverno_deprecated_api_requests_total{field!=""}) by (kind, field)`
+
+---
+
 ## HTTP Metrics
 
 ### HTTP Requests Count


### PR DESCRIPTION
## Summary

Documents the Phase 1 deprecation plumbing shipped in kyverno/kyverno#17362 for kyverno/kyverno#17214.

## Changes

- **Metrics reference** (`docs/reference/metrics`): adds the new `kyverno_deprecated_api_requests_total` counter with its `group`/`version`/`kind`/`field` labels, use cases, and example queries.
- **CEL migration guide** (`docs/guides/migration-to-cel`): adds a new **Detecting Legacy Policy Usage** section covering:
  - admission warnings for legacy `kyverno.io` policy types and deprecated field values (lowercase `enforce`/`audit` validation failure actions)
  - the same warnings printed by `kyverno apply` / `kyverno test`
  - the new `--warnings-as-errors` CLI flag for CI enforcement
  - the new metric for tracking deprecated API usage
- **CLI references** (`kyverno_apply`, `kyverno_test`): adds the `--warnings-as-errors` flag, matching the generated CLI docs from kyverno/kyverno#17362 (these will be re-synced by `codegen:cli-docs` at release time).
- **Policy types overview**: links the detection tooling from the deprecation schedule section.

## Validation

- `npm run build` passes (762 pages built)
- `npx prettier --check` passes on all changed files
- Verified the new anchors (`#deprecated-api-requests-count`, `#detecting-legacy-policy-usage`) resolve in the built output