### PR TITLE
docs: add kyverno_legacy_policies_total to the metrics reference

### DIFF
--- a/src/content/docs/docs/guides/migration-to-cel.md
+++ b/src/content/docs/docs/guides/migration-to-cel.md
@@ -324,6 +324,28 @@ kyverno test . --warnings-as-errors
 
 The `kyverno_deprecated_api_requests_total` counter, labeled by `group`, `version`, `kind`, and `field`, tracks admission requests that use deprecated policy types or fields. Use it to confirm that nothing in the cluster still creates or updates legacy policies before upgrading. See the [metrics reference](/docs/reference/metrics#deprecated-api-requests-count) for details and example queries.
 
+The counter only records active requests, so it cannot report legacy policies that already exist but that nobody is currently writing. The `kyverno_legacy_policies_total` gauge, labeled by `group` and `kind`, reports the legacy policy resources present in the cluster at rest and returns to `0` once you migrate or delete them. Use it to answer "have I migrated everything yet?":
+
+```
+sum(kyverno_legacy_policies_total) by (kind)
+```
+
+Alert while any legacy policy remains, so the migration is completed before you upgrade to a release that removes the legacy types:
+
+```
+sum(kyverno_legacy_policies_total) > 0
+```
+
+See the [metrics reference](/docs/reference/metrics#legacy-policies-count) for details.
+
+**Startup Signals**
+
+When any legacy policy is present, `kyverno-init` (the `kyverno-pre` init container) logs an error and emits a `LegacyPolicyPresent` warning event on the admission controller Deployment as it starts, listing the legacy kinds it still finds and linking to this guide. These signals fire on install, upgrade, or a controller restart, so restarting the admission controller after migrating confirms that nothing remains:
+
+```bash
+kubectl get events -n <kyverno-namespace> --field-selector reason=LegacyPolicyPresent
+```
+
 ## Troubleshooting
 
 **CEL Expression Errors**

--- a/src/content/docs/docs/reference/metrics.md
+++ b/src/content/docs/docs/reference/metrics.md
@@ -623,6 +623,42 @@ Counter - An only-increasing integer representing the count of admission request
 
 ---
 
+### Legacy Policies Count
+
+#### Metric Name(s)
+
+- `kyverno_legacy_policies_total`
+
+#### Metric Value
+
+Gauge - The number of legacy `kyverno.io` policy resources currently present in the cluster, per kind. The value is recomputed at scrape time, so it reflects the live count and returns to `0` once the resources are migrated or deleted.
+
+This gauge complements `kyverno_deprecated_api_requests_total`: the request counter records admission requests to deprecated APIs (flow), while this gauge reports the legacy resources that exist at rest, which the request counter cannot show when no client is currently writing them.
+
+#### Metric Labels
+
+| Label | Allowed Values                                                                        | Description                      |
+| ----- | ------------------------------------------------------------------------------------- | -------------------------------- |
+| group | "kyverno.io"                                                                          | API group of the legacy resource |
+| kind  | "ClusterPolicy", "Policy", "PolicyException", "CleanupPolicy", "ClusterCleanupPolicy" | Kind of the legacy resource      |
+
+The `ClusterPolicy`, `Policy`, and `PolicyException` series are exposed by the admission controller; the `CleanupPolicy` and `ClusterCleanupPolicy` series are exposed by the cleanup controller. The `PolicyException` series is only exposed when the admission controller runs with `--enablePolicyException=true`.
+
+#### Use cases
+
+- The cluster admin wants to confirm no legacy `kyverno.io` policies remain before upgrading to a release that removes them.
+- The cluster admin wants to alert while any legacy policy still exists, so the migration is completed in time.
+
+#### Useful Queries
+
+- Legacy policies still present, grouped by kind:<br>
+  `sum(kyverno_legacy_policies_total) by (kind)`
+
+- Alerting expression that fires while any legacy policy remains:<br>
+  `sum(kyverno_legacy_policies_total) > 0`
+
+---
+
 ## HTTP Metrics
 
 ### HTTP Requests Count


### PR DESCRIPTION
## What this does

Documents the new legacy-policy signals in two places:

- **Metrics reference** (`reference/metrics.md`): adds an entry for the `kyverno_legacy_policies_total` gauge, which reports how many legacy `kyverno.io` policy resources still exist in the cluster, per kind. It sits next to the existing `kyverno_deprecated_api_requests_total` counter, which it complements: the counter tracks requests to deprecated APIs (flow), while the gauge reports the legacy resources that exist at rest (stock). The entry covers the value, labels (`group`, `kind`), which controller exposes which series, the `--enablePolicyException` condition for the `PolicyException` series, use cases, and example queries.
- **Migration guide** (`guides/migration-to-cel.md`): in the "Detecting Legacy Policy Usage" section, points users at the gauge (to answer "have I migrated everything yet?") and at the `kyverno-init` startup log and `LegacyPolicyPresent` event, so they can confirm no legacy policies remain before upgrading.

## Related

Documents the feature added in kyverno/kyverno#17519 (issue kyverno/kyverno#17488).
