### PR TITLE
docs: document the 1.20 legacy-policy Helm install/upgrade gate

### DIFF
--- a/src/content/docs/docs/guides/migration-to-cel.md
+++ b/src/content/docs/docs/guides/migration-to-cel.md
@@ -324,6 +324,10 @@ kyverno test . --warnings-as-errors
 
 The `kyverno_deprecated_api_requests_total` counter, labeled by `group`, `version`, `kind`, and `field`, tracks admission requests that use deprecated policy types or fields. Use it to confirm that nothing in the cluster still creates or updates legacy policies before upgrading. See the [metrics reference](/docs/reference/metrics#deprecated-api-requests-count) for details and example queries.
 
+**Blocking Upgrades Until Migration Is Complete**
+
+Starting with Kyverno v1.20, the Helm chart blocks `helm install` and `helm upgrade` by default while any legacy `kyverno.io` policy resources still exist, so an upgrade cannot silently leave them behind. See [Upgrading to Kyverno v1.20](/docs/installation/upgrading) for the opt-out value and the bypass details.
+
 ## Troubleshooting
 
 **CEL Expression Errors**

--- a/src/content/docs/docs/installation/upgrading.md
+++ b/src/content/docs/docs/installation/upgrading.md
@@ -19,6 +19,43 @@ Direct upgrades from previous versions are not supported when using the YAML man
 
 An upgrade from versions prior to Kyverno 1.10 to versions at 1.10 or higher using Helm requires manual intervention and cannot be performed via a direct upgrade process. Please see the Helm chart v2 to v3 migration guide [here](https://github.com/kyverno/kyverno/blob/release-1.13/charts/kyverno/README.md#migrating-from-v2-to-v3) for more complete information.
 
+## Upgrading to Kyverno v1.20
+
+### Legacy policy resources block install and upgrade
+
+Kyverno v1.19 deprecated the legacy `kyverno.io` policy types (see [Deprecations](#deprecations) below). In v1.20, the Helm chart **blocks `helm install` and `helm upgrade` by default** while any legacy policy resources still exist on the cluster, so that you migrate them before completing the upgrade. The affected types are `ClusterPolicy` and `Policy` (`kyverno.io/v1`), `CleanupPolicy` and `ClusterCleanupPolicy` (`kyverno.io/v2`), and the legacy `PolicyException` (`kyverno.io/v2`).
+
+The gate has two layers:
+
+- A **render-time check** that runs during `helm install` and `helm upgrade` against a live cluster and fails with the offending resource counts and names.
+- A **`pre-install`/`pre-upgrade` hook Job** for GitOps tools that apply Helm hooks server-side, such as Argo CD and Flux.
+
+To complete the upgrade, first migrate your legacy policies to the CEL-based [policy types](/docs/policy-types/overview) using the [migration guide](/docs/guides/migration-to-cel), then confirm none remain:
+
+```bash
+kubectl get clusterpolicies,policies,cleanuppolicies,clustercleanuppolicies -A
+kubectl get policyexceptions.kyverno.io -A
+```
+
+If you must upgrade before completing the migration, set the opt-out value to disable the gate:
+
+```bash
+helm upgrade --install kyverno kyverno/kyverno -n kyverno --create-namespace \
+  --set upgrade.allowLegacyPolicies=true
+```
+
+`upgrade.allowLegacyPolicies=true` disables both layers. To disable only the hook Job while keeping the render-time check, set `upgrade.legacyPolicyCheck.enabled=false`.
+
+#### Bypasses
+
+Both layers require Helm to evaluate against a live cluster, so the following paths skip the gate:
+
+- `helm template`, client-side `helm install --dry-run` (`--dry-run=client`), and chart linting (`ct lint`) never populate the cluster `lookup`, so the render-time check passes. Server-side `helm install --dry-run=server` does connect to the cluster and is covered.
+- `helm install`/`helm upgrade --no-hooks`, Argo CD's `Skip Hooks` sync option, and Flux's `spec.install.disableHooks` / `spec.upgrade.disableHooks` skip the hook Job.
+- Installing from Kyverno's static YAML manifests skips both layers.
+
+If your install method bypasses the gate, run the preflight commands above before you upgrade.
+
 ## Upgrading to Kyverno v1.19
 
 ### Deprecations


### PR DESCRIPTION
## Related issue

Documents the phase 2 legacy-policy enforcement for kyverno/kyverno#17214, implemented in kyverno/kyverno#17490 (code PR kyverno/kyverno#17534). Companion to the phase 1 detection docs (#2148) and the sibling metrics docs (#2154). 

## Proposed Changes

Kyverno v1.20 makes the Helm chart block `helm install` and `helm upgrade` by default while any legacy `kyverno.io` policy resources still exist, so that operators migrate them before completing the upgrade. This PR documents that behavior for users.

- **`installation/upgrading.md`** — add an "Upgrading to Kyverno v1.20" section (newest-first, above v1.19) covering:
  - the two layers of the gate (a render-time `lookup` check, and a `pre-install`/`pre-upgrade` hook Job for GitOps tools that apply hooks server-side);
  - the affected types (`ClusterPolicy`, `Policy`, `CleanupPolicy`, `ClusterCleanupPolicy`, and the legacy `PolicyException`);
  - the `upgrade.allowLegacyPolicies=true` opt-out, and `upgrade.legacyPolicyCheck.enabled=false` to disable only the hook Job;
  - `kubectl` preflight commands to confirm no legacy resources remain;
  - the bypass paths (offline renders and `--dry-run=client`, `--no-hooks`, Argo CD `Skip Hooks`, Flux `disableHooks`, and static YAML manifests), including that `--dry-run=server` is still covered.
- **`guides/migration-to-cel.md`** — cross-reference the gate from the existing "Detecting Legacy Policy Usage" section so the migration guide points to the upgrade behavior without duplicating it.

The detailed content lives in the upgrade guide; the migration guide links to it.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/website/blob/main/CONTRIBUTING.md).
- [ ] I have inspected the website preview for accuracy.
- [x] I have signed off my issue.
